### PR TITLE
[MINOR] Package names don't correspond to directory structure

### DIFF
--- a/streaming-mqtt/src/main/scala/org/apache/spark/streaming/mqtt/package.scala
+++ b/streaming-mqtt/src/main/scala/org/apache/spark/streaming/mqtt/package.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.spark.streaming.mqtt
+package org.apache.spark.streaming
 
 /**
  * MQTT receiver for Spark Streaming.

--- a/streaming-twitter/src/main/scala/org/apache/spark/streaming/twitter/package.scala
+++ b/streaming-twitter/src/main/scala/org/apache/spark/streaming/twitter/package.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.spark.streaming.twitter
+package org.apache.spark.streaming
 
 /**
  * Twitter feed receiver for spark streaming.

--- a/streaming-zeromq/src/main/scala/org/apache/spark/streaming/zeromq/package.scala
+++ b/streaming-zeromq/src/main/scala/org/apache/spark/streaming/zeromq/package.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.spark.streaming.zeromq
+package org.apache.spark.streaming
 
 /**
  * Zeromq receiver for spark streaming.


### PR DESCRIPTION
Package names in `package.scala` files do not correspond to directories structure for **MQTT, Twitter** and **ZeroMQ** modules. This may cause (future) problems with resolve to classes from these `package.scala` files.

Notice the path of the generated `package.class` files before this fix (i.e. `".../mqtt/mqtt/..."`):

``` console
$ mvn clean install
$ find . -name package.class | grep -v akka
./streaming-mqtt/target/scala-2.11/classes/org/apache/spark/streaming/mqtt/mqtt/package.class
./streaming-twitter/target/scala-2.11/classes/org/apache/spark/streaming/twitter/twitter/package.class
./streaming-zeromq/target/scala-2.11/classes/org/apache/spark/streaming/zeromq/zeromq/package.class
```

... and after:

``` console
$ mvn clean install
$ find . -name package.class | grep -v akka
./streaming-mqtt/target/scala-2.11/classes/org/apache/spark/streaming/mqtt/package.class
./streaming-twitter/target/scala-2.11/classes/org/apache/spark/streaming/twitter/package.class
./streaming-zeromq/target/scala-2.11/classes/org/apache/spark/streaming/zeromq/package.class
```
