### PR TITLE
[MINOR] add custom messages for import style checks to scalastyle-config.xml

### DIFF
--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -218,6 +218,7 @@ This file is divided into 3 sections:
       <parameter name="group.3rdParty">(?!org\.apache\.spark\.).*</parameter>
       <parameter name="group.spark">org\.apache\.spark\..*</parameter>
     </parameters>
+    <customMessage>Imports should be grouped and ordered: java,scala,3rdParty,spark</customMessage>
   </check>
 
   <check level="error" class="org.scalastyle.scalariform.DisallowSpaceBeforeTokenChecker" enabled="true">
@@ -270,6 +271,7 @@ This file is divided into 3 sections:
 
   <check level="error" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="false">
     <parameters><parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter></parameters>
+    <customMessage>Illegal import of sun._ or java.awt._</customMessage>
   </check>
 
   <!-- We want the opposite of this: NewLineAtEofChecker -->


### PR DESCRIPTION
I am adding a few custom messages to the Scala Style configuration. Short of those, there is no way to determine what the red squiggly line means in IntelliJ. Many of the remaining checks may also benefit from custom messages so I mark this PR as work-in-progress.
