### PR TITLE
[BAHIR-35] add Python sources to binary jar for use with `spark-submit --packages …`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -374,6 +374,15 @@
   </dependencyManagement>
 
   <build>
+    <resources>
+      <resource>
+        <directory>${basedir}/python</directory>
+        <includes>
+          <include>**/*.py</include>
+        </includes>
+      </resource>
+    </resources>
+
     <pluginManagement>
       <plugins>
         <plugin>


### PR DESCRIPTION
[BAHIR-35: Include Python code in the binary jars for use with "--packages ..."](https://issues.apache.org/jira/browse/BAHIR-35)

**Change:**

Adding `${basedir}/python/**/*.py` files as `<resources>` in the build section of `pom.xml`:

``` xml
...
  <build>
    <resources>
      <resource>
        <directory>${basedir}/python</directory>
        <includes>
          <include>**/*.py</include>
        </includes>
      </resource>
    </resources>
    ...
```

Currently only the **MQTT** Streaming connector is affected by this change.

**Test:**

After PR #10 is merged, run the following commands:

``` console
mvn clean install

rm -rf ~/.ivy2/cache/org.apache.bahir/

mosquitto -p 1883

bin/run-example \
    org.apache.spark.examples.streaming.mqtt.MQTTPublisher tcp://localhost:1883 foo

${SPARK_HOME}/bin/spark-submit \
    --packages org.apache.bahir:spark-streaming-mqtt_2.11:2.0.0-SNAPSHOT \
    streaming-mqtt/examples/src/main/python/streaming/mqtt_wordcount.py \
    tcp://localhost:1883 foo
```

![python sources in mqtt module](https://cloud.githubusercontent.com/assets/12246093/17070311/011430f4-5010-11e6-8370-769f6379993b.png)

![python sources in mqtt binary jar](https://cloud.githubusercontent.com/assets/12246093/17070316/0999fd8a-5010-11e6-9832-b7847ab70404.png)
