### PR TITLE
[BAHIR-38] clean Ivy cache during Maven install phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -944,6 +944,37 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-clean-plugin</artifactId>
+        <executions>
+          <!--
+            When we `install` the org.apache.bahir jars into the local Maven repository we also need
+            to clean the previous jar files from the Ivy cache (~/iv2/cache/org.apache.bahir/*) so
+            `spark-submit -packages ...` will pick up the new version from the the local Maven repository
+          -->
+          <execution>
+            <id>cleanup-ivy-cache</id>
+            <phase>install</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+            <configuration>
+              <followSymLinks>false</followSymLinks>
+              <excludeDefaultDirectories>true</excludeDefaultDirectories>
+              <filesets>
+                <fileset>
+                  <directory>${user.home}/.ivy2/cache/${project.groupId}/${project.artifactId}</directory>
+                  <includes>
+                    <include>*-${project.version}.*</include>
+                    <include>jars/${project.build.finalName}.jar</include>
+                  </includes>
+                </fileset>
+              </filesets>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
[BAHIR-38: Spark-submit does not use latest locally installed Bahir packages](https://issues.apache.org/jira/browse/BAHIR-38)

When we `install` the org.apache.bahir jars into the local Maven repository we also need to clean the previous jar files from the Ivy cache (~/iv2/cache/org.apache.bahir/*) so `spark-submit -packages ...` will pick up the new version from the the local Maven repository.

_pom.xml:_

``` xml
  <build>
    <plugins>
      ...
      <plugin>
        <groupId>org.apache.maven.plugins</groupId>
        <artifactId>maven-clean-plugin</artifactId>
        <executions>
          <execution>
            <id>cleanup-ivy-cache</id>
            <phase>install</phase>
            <goals>
              <goal>clean</goal>
            </goals>
            <configuration>
              <followSymLinks>false</followSymLinks>
              <excludeDefaultDirectories>true</excludeDefaultDirectories>
              <filesets>
                <fileset>
                  <directory>${user.home}/.ivy2/cache/${project.groupId}/${project.artifactId}</directory>
                  <includes>
                    <include>*-${project.version}.*</include>
                    <include>jars/${project.artifactId}-${project.version}.jar</include>
                  </includes>
                </fileset>
              </filesets>
            </configuration>
          </execution>
        </executions>
      </plugin>
    </plugins>
  </build>
  ...
```

**Test**

(1) Start with an empty Ivy cache:

``` console
[bahir]$ rm -rf ~/.ivy2/cache/org.apache.bahir/*
[bahir]$ tree ~/.ivy2/cache/org.apache.bahir/ 

0 directories, 0 files
```

(2) Run an install build:

``` console
[bahir]$ mvn clean install -DskipTests  2>&1  | grep -E "ERROR|SUCCESS|FAIL"

[INFO] Apache Bahir - Parent POM .......................... SUCCESS [  3.472 s]
[INFO] Apache Bahir - Spark Streaming Akka ................ SUCCESS [ 11.806 s]
[INFO] Apache Bahir - Spark Streaming MQTT ................ SUCCESS [ 13.265 s]
[INFO] Apache Bahir - Spark Streaming Twitter ............. SUCCESS [  7.532 s]
[INFO] Apache Bahir - Spark Streaming ZeroMQ .............. SUCCESS [  7.366 s]
[INFO] BUILD SUCCESS
```

(3) Run spark-submit with a Bahir package (i.e. streaming-akka with MQTT wordcount, this is a no-op -> the `ImportError` at end is expected):

``` console
[bahir]$ ${SPARK_HOME}/bin/spark-submit \
    --packages org.apache.bahir:spark-streaming-akka_2.11:2.0.0-SNAPSHOT \
    streaming-mqtt/examples/src/main/python/streaming/mqtt_wordcount.py

Ivy Default Cache set to: ~/.ivy2/cache
The jars for the packages stored in: ~/.ivy2/jars
...
org.apache.bahir#spark-streaming-akka_2.11 added as a dependency
:: resolving dependencies :: org.apache.spark#spark-submit-parent;1.0
    ...
    found org.apache.bahir#spark-streaming-akka_2.11;2.0.0-SNAPSHOT in local-m2-cache
🔴downloading file:~/.m2/repository/org/apache/bahir/spark-streaming-akka_2.11/2.0.0-SNAPSHOT/spark-streaming-akka_2.11-2.0.0-SNAPSHOT.jar ...
    [SUCCESSFUL ] org.apache.bahir#spark-streaming-akka_2.11;2.0.0-SNAPSHOT!spark-streaming-akka_2.11.jar (2ms)
...

ImportError: No module named mqtt
```

(4) Check the Ivy cache:

``` console
[bahir]$ tree ~/.ivy2/cache/org.apache.bahir/

~/.ivy2/cache/org.apache.bahir/
├── bahir-parent_2.11
│   ├── ivy-2.0.0-SNAPSHOT.xml
│   ├── ivy-2.0.0-SNAPSHOT.xml.original
│   └── ivydata-2.0.0-SNAPSHOT.properties
└── spark-streaming-akka_2.11
    ├── ivy-2.0.0-SNAPSHOT.xml
    ├── ivy-2.0.0-SNAPSHOT.xml.original
    ├── ivydata-2.0.0-SNAPSHOT.properties
    └── jars
        └── spark-streaming-akka_2.11-2.0.0-SNAPSHOT.jar🔴

3 directories, 7 files
```

(5) Run an install build for the streaming-akka:

``` console
[bahir]$ mvn install -DskipTests -pl streaming-akka  2>&1 | \
    grep -E "ERROR|SUCCESS|FAIL|Deleting"

[INFO] 🔴 Deleting ~/.ivy2/cache/org.apache.bahir/spark-streaming-akka_2.11 (includes = [*-2.0.0-SNAPSHOT.*, jars/spark-streaming-akka_2.11-2.0.0-SNAPSHOT.jar], excludes = [])
[INFO] BUILD SUCCESS
```

(6) Check the Ivy cache again, all files related to streaming-akka are gone:

``` console
[bahir]$ tree ~/.ivy2/cache/org.apache.bahir/

~/.ivy2/cache/org.apache.bahir/
├── bahir-parent_2.11
│   ├── ivy-2.0.0-SNAPSHOT.xml
│   ├── ivy-2.0.0-SNAPSHOT.xml.original
│   └── ivydata-2.0.0-SNAPSHOT.properties
└── spark-streaming-akka_2.11
    └── jars 🔴

3 directories, 3 files
```
