### PR TITLE
[BAHIR-73][bahir-flink] flink-streaming-akka source connector

### DIFF
--- a/flink-streaming-akka/pom.xml
+++ b/flink-streaming-akka/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.bahir</groupId>
+        <artifactId>bahir-parent_2.11</artifactId>
+        <version>2.1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.apache.bahir</groupId>
+    <artifactId>flink-streaming-akka_2.11</artifactId>
+    <name>Apache Bahir - Flink Streaming Akka</name>
+    <url>http://bahir.apache.org/</url>
+    <packaging>jar</packaging>
+
+    <properties>
+        <mockito.version>1.10.19</mockito.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${akka.group}</groupId>
+            <artifactId>akka-actor_${scala.binary.version}</artifactId>
+            <version>${akka.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${akka.group}</groupId>
+            <artifactId>akka-remote_${scala.binary.version}</artifactId>
+            <version>${akka.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>${mockito.version}</version>
+            <type>jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/flink-streaming-akka/src/main/java/org/apache/flink/streaming/connectors/akka/AkkaSource.java
+++ b/flink-streaming-akka/src/main/java/org/apache/flink/streaming/connectors/akka/AkkaSource.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.akka;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.actor.PoisonPill;
+import akka.actor.Props;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.functions.StoppableFunction;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
+import org.apache.flink.streaming.connectors.akka.utils.ReceiverActor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implementation of {@link SourceFunction} specialized to read messages
+ * from Akka actors.
+ */
+public class AkkaSource extends RichSourceFunction<Object>
+  implements StoppableFunction {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AkkaSource.class);
+
+  private static final long serialVersionUID = 1L;
+
+  // --- Fields set by the constructor
+
+  private final Class<?> classForActor;
+
+  private final String actorName;
+
+  private final String urlOfPublisher;
+
+  // --- Runtime fields
+  private transient ActorSystem receiverActorSystem;
+  private transient ActorRef receiverActor;
+  private transient Object waitLock;
+  private transient boolean running = true;
+
+  protected transient boolean autoAck;
+
+  /**
+   * Creates {@link AkkaSource} for Streaming
+   *
+   * @param actorName Receiver Actor name
+   * @param urlOfPublisher tcp url of the publisher or feeder actor
+   */
+  public AkkaSource(String actorName,
+          String urlOfPublisher) {
+    super();
+    this.classForActor = ReceiverActor.class;
+    this.actorName = actorName;
+    this.urlOfPublisher = urlOfPublisher;
+  }
+
+  @Override
+  public void open(Configuration parameters) throws Exception {
+    waitLock = new Object();
+    receiverActorSystem = createDefaultActorSystem();
+
+    RuntimeContext runtimeContext = getRuntimeContext();
+    if (runtimeContext instanceof StreamingRuntimeContext
+      && ((StreamingRuntimeContext) runtimeContext).isCheckpointingEnabled()) {
+      autoAck = false;
+    } else {
+      autoAck = true;
+    }
+  }
+
+  @Override
+  public void run(SourceFunction.SourceContext<Object> ctx) throws Exception {
+    LOG.info("Starting the Receiver actor {}", actorName);
+    receiverActor = receiverActorSystem.actorOf(
+      Props.create(classForActor, ctx, urlOfPublisher, autoAck), actorName);
+
+    running = true;
+    LOG.info("Started the Receiver actor {} successfully", actorName);
+
+    while (running) {
+      synchronized (waitLock) {
+        waitLock.wait(100L);
+      }
+    }
+  }
+
+  @Override
+  public void close() {
+    this.running = false;
+    LOG.info("Closing source");
+    if (receiverActorSystem != null) {
+      receiverActor.tell(PoisonPill.getInstance(), ActorRef.noSender());
+      receiverActorSystem.shutdown();
+      receiverActorSystem.awaitTermination();
+    }
+    synchronized (waitLock) {
+      waitLock.notify();
+    }
+  }
+
+  @Override
+  public void cancel() {
+    LOG.info("Cancelling akka source");
+    close();
+  }
+
+  @Override
+  public void stop() {
+    LOG.info("Stopping akka source");
+    close();
+  }
+
+  /**
+   * Creates an actor system with default configurations for Receiver actor.
+   *
+   * @return Actor System instance with default configurations
+   */
+  private ActorSystem createDefaultActorSystem() {
+    String defaultActorSystemName = "receiver-actor-system";
+
+    String configString = "akka.actor.provider = \"akka.remote.RemoteActorRefProvider\"\n" +
+      "akka.remote.enabled-transports = [\"akka.remote.netty.tcp\"]";
+    Config defaultConfig = ConfigFactory.parseString(configString);
+
+    return ActorSystem.create(defaultActorSystemName, defaultConfig);
+  }
+}

--- a/flink-streaming-akka/src/main/java/org/apache/flink/streaming/connectors/akka/package-info.java
+++ b/flink-streaming-akka/src/main/java/org/apache/flink/streaming/connectors/akka/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Akka receiver for Flink Streaming.
+ */
+package org.apache.flink.streaming.connectors.akka;

--- a/flink-streaming-akka/src/main/java/org/apache/flink/streaming/connectors/akka/utils/ReceiverActor.java
+++ b/flink-streaming-akka/src/main/java/org/apache/flink/streaming/connectors/akka/utils/ReceiverActor.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.akka.utils;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSelection;
+import akka.actor.UntypedActor;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext;
+
+import java.util.Iterator;
+
+/**
+ * Generalized receiver actor which receives messages
+ * from the feeder or publisher actor.
+ */
+public class ReceiverActor extends UntypedActor {
+  // --- Fields set by the constructor
+  private final SourceContext<Object> ctx;
+
+  private final String urlOfPublisher;
+
+  private final boolean autoAck;
+
+  // --- Runtime fields
+  private ActorSelection remotePublisher;
+
+  public ReceiverActor(SourceContext<Object> ctx,
+            String urlOfPublisher,
+            boolean autoAck) {
+    this.ctx = ctx;
+    this.urlOfPublisher = urlOfPublisher;
+    this.autoAck = autoAck;
+  }
+
+  @Override
+  public void preStart() throws Exception {
+    remotePublisher = getContext().actorSelection(urlOfPublisher);
+    remotePublisher.tell(new SubscribeReceiver(getSelf()), getSelf());
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public void onReceive(Object message)
+    throws Exception {
+    if (message instanceof Iterable) {
+      collect((Iterable<Object>) message);
+    } else if (message instanceof byte[]) {
+      byte[] messageBytes = (byte[]) message;
+      collect(messageBytes);
+    } else if (message instanceof Tuple2) {
+      Tuple2<Object, Long> messageTuple = (Tuple2<Object, Long>) message;
+      collect(messageTuple.f0, messageTuple.f1);
+    } else {
+      collect(message);
+    }
+
+    if (autoAck) {
+      getSender().tell("ack", getSelf());
+    }
+  }
+
+  /**
+   * To handle {@link Iterable} data
+   *
+   * @param data data received from feeder actor
+   */
+  private void collect(Iterable<Object> data) {
+    Iterator<Object> iterator = data.iterator();
+    while (iterator.hasNext()) {
+      ctx.collect(iterator.next());
+    }
+  }
+
+  /**
+   * To handle byte array data
+   *
+   * @param bytes data received from feeder actor
+   */
+  private void collect(byte[] bytes) {
+    ctx.collect(bytes);
+  }
+
+  /**
+   * To handle single data
+   * @param data data received from feeder actor
+   */
+  private void collect(Object data) {
+    ctx.collect(data);
+  }
+
+  /**
+   * To handle data with timestamp
+   *
+   * @param data data received from feeder actor
+   * @param timestamp timestamp received from feeder actor
+   */
+  private void collect(Object data, long timestamp) {
+    ctx.collectWithTimestamp(data, timestamp);
+  }
+
+  @Override
+  public void postStop() throws Exception {
+    remotePublisher.tell(new UnsubscribeReceiver(ActorRef.noSender()),
+      ActorRef.noSender());
+  }
+}

--- a/flink-streaming-akka/src/main/java/org/apache/flink/streaming/connectors/akka/utils/SubscribeReceiver.java
+++ b/flink-streaming-akka/src/main/java/org/apache/flink/streaming/connectors/akka/utils/SubscribeReceiver.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.akka.utils;
+
+import akka.actor.ActorRef;
+
+import java.io.Serializable;
+
+/**
+ * General interface used by Receiver Actor to subscribe
+ * to the publisher.
+ */
+public class SubscribeReceiver implements Serializable {
+  private static final long serialVersionUID = 1L;
+  private ActorRef receiverActor;
+
+  public SubscribeReceiver(ActorRef receiverActor) {
+    this.receiverActor = receiverActor;
+  }
+
+  public void setReceiverActor(ActorRef receiverActor) {
+    this.receiverActor = receiverActor;
+  }
+
+  public ActorRef getReceiverActor() {
+    return receiverActor;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof SubscribeReceiver) {
+      SubscribeReceiver other = (SubscribeReceiver) obj;
+      return other.canEquals(this) && super.equals(other)
+        && receiverActor.equals(other.getReceiverActor());
+    } else {
+      return false;
+    }
+  }
+
+  public boolean canEquals(Object obj) {
+    return obj instanceof SubscribeReceiver;
+  }
+}

--- a/flink-streaming-akka/src/main/java/org/apache/flink/streaming/connectors/akka/utils/UnsubscribeReceiver.java
+++ b/flink-streaming-akka/src/main/java/org/apache/flink/streaming/connectors/akka/utils/UnsubscribeReceiver.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.akka.utils;
+
+import akka.actor.ActorRef;
+
+import java.io.Serializable;
+
+/**
+ * General interface used by Receiver Actor to un subscribe.
+ */
+public class UnsubscribeReceiver implements Serializable {
+  private static final long serialVersionUID = 1L;
+  private ActorRef receiverActor;
+
+  public UnsubscribeReceiver(ActorRef receiverActor) {
+    this.receiverActor = receiverActor;
+  }
+
+  public void setReceiverActor(ActorRef receiverActor) {
+    this.receiverActor = receiverActor;
+  }
+
+  public ActorRef getReceiverActor() {
+    return receiverActor;
+  }
+
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof UnsubscribeReceiver) {
+      UnsubscribeReceiver other = (UnsubscribeReceiver) obj;
+      return other.canEquals(this) && super.equals(other)
+        && receiverActor.equals(other.getReceiverActor());
+    } else {
+      return false;
+    }
+  }
+
+  public boolean canEquals(Object obj) {
+    return obj instanceof UnsubscribeReceiver;
+  }
+}

--- a/flink-streaming-akka/src/test/java/org/apache/flink/streaming/connectors/akka/AkkaSourceTest.java
+++ b/flink-streaming-akka/src/test/java/org/apache/flink/streaming/connectors/akka/AkkaSourceTest.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.akka;
+
+import akka.actor.ActorSystem;
+import akka.actor.Props;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.connectors.akka.utils.FeederActor;
+import org.apache.flink.streaming.connectors.akka.utils.Message;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+public class AkkaSourceTest {
+  private AkkaSource source;
+
+  private static final String feederActorName = "JavaFeederActor";
+  private static final String receiverActorName = "receiverActor";
+  private static final String urlOfFeeder =
+    "akka.tcp://feederActorSystem@127.0.0.1:5150/user/" + feederActorName;
+  private ActorSystem feederActorSystem;
+
+  private Configuration config = new Configuration();
+
+  private Thread sourceThread;
+
+  private SourceFunction.SourceContext<Object> sourceContext;
+
+  private volatile Exception exception;
+
+  @Before
+  public void beforeTest() throws Exception {
+    feederActorSystem = ActorSystem.create("feederActorSystem",
+      getFeederActorConfig());
+
+    source = new AkkaTestSource();
+    source.open(config);
+
+    sourceContext = new DummySourceContext();
+
+    sourceThread = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          SourceFunction.SourceContext<Object> sourceContext =
+            new DummySourceContext();
+          source.run(sourceContext);
+        } catch (Exception e) {
+          exception = e;
+        }
+      }
+    });
+  }
+
+  @After
+  public void afterTest() throws Exception {
+    feederActorSystem.shutdown();
+    feederActorSystem.awaitTermination();
+
+    source.cancel();
+    sourceThread.join();
+  }
+
+  @Test
+  public void testWithSingleData() throws Exception {
+    feederActorSystem.actorOf(
+      Props.create(FeederActor.class, FeederActor.MessageTypes.SINGLE_DATA),
+      feederActorName);
+
+    source.autoAck = false;
+    sourceThread.start();
+
+    while (DummySourceContext.numElementsCollected != 1) {
+      Thread.sleep(5);
+    }
+    List<Object> message = DummySourceContext.message;
+    Assert.assertEquals(message.get(0).toString(), Message.WELCOME_MESSAGE);
+  }
+
+  @Test
+  public void testWithIterableData() throws Exception {
+    feederActorSystem.actorOf(
+      Props.create(FeederActor.class, FeederActor.MessageTypes.ITERABLE_DATA),
+      feederActorName);
+
+    source.autoAck = false;
+    sourceThread.start();
+
+    while (DummySourceContext.numElementsCollected != 2) {
+      Thread.sleep(5);
+    }
+
+    List<Object> messages = DummySourceContext.message;
+    Assert.assertEquals(messages.get(0).toString(), Message.WELCOME_MESSAGE);
+    Assert.assertEquals(messages.get(1).toString(), Message.FEEDER_MESSAGE);
+  }
+
+  @Test
+  public void testWithByteArrayData() throws Exception {
+    feederActorSystem.actorOf(
+      Props.create(FeederActor.class, FeederActor.MessageTypes.BYTES_DATA),
+      feederActorName);
+
+    source.autoAck = false;
+    sourceThread.start();
+
+    while (DummySourceContext.numElementsCollected != 1) {
+      Thread.sleep(5);
+    }
+
+    List<Object> message = DummySourceContext.message;
+    if (message.get(0) instanceof byte[]) {
+      byte[] data = (byte[]) message.get(0);
+      Assert.assertEquals(new String(data), Message.WELCOME_MESSAGE);
+    }
+  }
+
+  @Test
+  public void testWithSingleDataWithTimestamp() throws Exception {
+    feederActorSystem.actorOf(
+      Props.create(FeederActor.class, FeederActor.MessageTypes.SINGLE_DATA_WITH_TIMESTAMP),
+      feederActorName);
+
+    source.autoAck = false;
+    sourceThread.start();
+
+    while (DummySourceContext.numElementsCollected != 1) {
+      Thread.sleep(5);
+    }
+
+    List<Object> message = DummySourceContext.message;
+    Assert.assertEquals(message.get(0).toString(), Message.WELCOME_MESSAGE);
+  }
+
+  @Test
+  public void testAcksWithSingleData() throws Exception {
+    feederActorSystem.actorOf(
+      Props.create(FeederActor.class, FeederActor.MessageTypes.SINGLE_DATA),
+      feederActorName);
+
+    source.autoAck = true;
+    sourceThread.start();
+
+    while (DummySourceContext.numElementsCollected != 1) {
+      Thread.sleep(5);
+    }
+    // assertion tested in FeederActor
+  }
+
+  private class AkkaTestSource extends AkkaSource {
+
+    private AkkaTestSource() {
+      super(receiverActorName, urlOfFeeder);
+    }
+
+    @Override
+    public RuntimeContext getRuntimeContext() {
+      return Mockito.mock(StreamingRuntimeContext.class);
+    }
+  }
+
+  private static class DummySourceContext implements SourceFunction.SourceContext<Object> {
+    private static final Object lock = new Object();
+
+    private static long numElementsCollected;
+
+    private static List<Object> message;
+
+    private DummySourceContext() {
+      numElementsCollected = 0;
+      message = new ArrayList<Object>();
+    }
+
+    @Override
+    public void collect(Object element) {
+      message.add(element);
+      numElementsCollected++;
+    }
+
+    @Override
+    public void collectWithTimestamp(Object element, long timestamp) {
+      message.add(element);
+      numElementsCollected++;
+    }
+
+    @Override
+    public void emitWatermark(Watermark mark) {
+
+    }
+
+    @Override
+    public Object getCheckpointLock() {
+      return lock;
+    }
+
+    @Override
+    public void close() {
+
+    }
+  }
+
+  private Config getFeederActorConfig() {
+    String configFile = getClass().getClassLoader()
+      .getResource("feeder_actor.conf").getFile();
+    Config config = ConfigFactory.parseFile(new File(configFile));
+    return config;
+  }
+}

--- a/flink-streaming-akka/src/test/java/org/apache/flink/streaming/connectors/akka/utils/FeederActor.java
+++ b/flink-streaming-akka/src/test/java/org/apache/flink/streaming/connectors/akka/utils/FeederActor.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.akka.utils;
+
+import akka.actor.ActorRef;
+import akka.actor.UntypedActor;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FeederActor extends UntypedActor {
+
+  public enum MessageTypes {
+    SINGLE_DATA, ITERABLE_DATA, BYTES_DATA,
+    SINGLE_DATA_WITH_TIMESTAMP
+  }
+
+  private static final Logger LOG = LoggerFactory.getLogger(FeederActor.class);
+
+  private final MessageTypes messageType;
+
+  public FeederActor(MessageTypes messageType) {
+    this.messageType = messageType;
+  }
+
+  @Override
+  public void onReceive(Object message) {
+    if (message instanceof SubscribeReceiver) {
+      ActorRef receiver = ((SubscribeReceiver) message).getReceiverActor();
+
+      Object data;
+      switch (messageType) {
+        case SINGLE_DATA:
+          data = createSingleDataMessage();
+          break;
+        case ITERABLE_DATA:
+          data = createIterableOfMessages();
+          break;
+        case BYTES_DATA:
+          data = createByteMessages();
+          break;
+        case SINGLE_DATA_WITH_TIMESTAMP:
+          data = createTimestampMessage();
+          break;
+        default:
+          throw new RuntimeException("Message format specified is incorrect");
+      }
+      receiver.tell(data, getSelf());
+    } else if (message instanceof String) {
+      Assert.assertEquals(message.toString(), "ack");
+    } else if (message instanceof UnsubscribeReceiver) {
+      LOG.info("Stop actor!");
+    }
+  }
+
+  private Object createSingleDataMessage() {
+    return Message.WELCOME_MESSAGE;
+  }
+
+  private List<Object> createIterableOfMessages() {
+    List<Object> messages = new ArrayList<Object>();
+
+    messages.add(Message.WELCOME_MESSAGE);
+    messages.add(Message.FEEDER_MESSAGE);
+
+    return messages;
+  }
+
+  private byte[] createByteMessages() {
+    byte[] message = Message.WELCOME_MESSAGE.getBytes();
+    return message;
+  }
+
+  private Tuple2<Object, Long> createTimestampMessage() {
+    Tuple2<Object, Long> message = new Tuple2<Object, Long>();
+    message.f0 = Message.WELCOME_MESSAGE;
+    message.f1 = System.currentTimeMillis();
+
+    return message;
+  }
+}

--- a/flink-streaming-akka/src/test/java/org/apache/flink/streaming/connectors/akka/utils/Message.java
+++ b/flink-streaming-akka/src/test/java/org/apache/flink/streaming/connectors/akka/utils/Message.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.akka.utils;
+
+public class Message {
+  public static final String WELCOME_MESSAGE = "welcome receiver";
+  public static final String FEEDER_MESSAGE = "this is feeder";
+}

--- a/flink-streaming-akka/src/test/resources/feeder_actor.conf
+++ b/flink-streaming-akka/src/test/resources/feeder_actor.conf
@@ -1,0 +1,33 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+akka {
+  loglevel = "INFO"
+  actor {
+    provider = "akka.remote.RemoteActorRefProvider"
+  }
+  remote {
+    enabled-transports = ["akka.remote.netty.tcp"]
+    netty.tcp {
+      hostname = 127.0.0.1
+      port = 5150
+    }
+    log-sent-messages = on
+    log-received-messages = on
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   </parent>
   <groupId>org.apache.bahir</groupId>
   <artifactId>bahir-parent_2.11</artifactId>
-  <version>2.1.0-SNAPSHOT</version>
+  <version>2.1.0-SNAPSHOT</version> 
   <packaging>pom</packaging>
   <name>Apache Bahir - Parent POM</name>
   <url>http://bahir.apache.org/</url>
@@ -80,6 +80,7 @@
     <module>sql-streaming-mqtt</module>
     <module>streaming-twitter</module>
     <module>streaming-zeromq</module>
+    <module>flink-streaming-akka</module>
   </modules>
 
   <properties>
@@ -94,6 +95,9 @@
     <maven.version>3.3.9</maven.version>
     <slf4j.version>1.7.16</slf4j.version>
     <log4j.version>1.2.17</log4j.version>
+
+    <!-- Flink version -->
+    <flink.version>1.1.3</flink.version>
 
     <!-- Spark version -->
     <spark.version>2.0.1</spark.version>


### PR DESCRIPTION
This PR is created to propose the idea of having a flink-streaming-akka source connector.

The source connector can be used to receive messages from an Akka feeder or publisher actor & these messages can then be processed using flink streaming.

The source connector has the following features.

It can supports several different message formats like iterable data, bytes array & data with timestamp.
It can send back acknowledgements to the feeder actor.

Reference to the closed PR in Flink: https://github.com/apache/flink/pull/2644

@rmetzger , kindly review.
