### PR TITLE
[BAHIR-84] Suppress Parquet-MR log messages from build log

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -565,6 +565,7 @@
             </environmentVariables>
             <systemProperties>
               <log4j.configuration>file:src/test/resources/log4j.properties</log4j.configuration>
+              <java.util.logging.config.file>${basedir}/src/test/resources/logging.properties</java.util.logging.config.file>
               <derby.system.durability>test</derby.system.durability>
               <java.awt.headless>true</java.awt.headless>
               <java.io.tmpdir>${project.build.directory}/tmp</java.io.tmpdir>
@@ -614,6 +615,7 @@
             </environmentVariables>
             <systemProperties>
               <log4j.configuration>file:src/test/resources/log4j.properties</log4j.configuration>
+              <java.util.logging.config.file>${basedir}/src/test/resources/logging.properties</java.util.logging.config.file>
               <derby.system.durability>test</derby.system.durability>
               <java.awt.headless>true</java.awt.headless>
               <java.io.tmpdir>${project.build.directory}/tmp</java.io.tmpdir>

--- a/sql-streaming-mqtt/src/test/resources/logging.properties
+++ b/sql-streaming-mqtt/src/test/resources/logging.properties
@@ -1,0 +1,70 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+############################################################
+#  	Global properties
+############################################################
+
+# "handlers" specifies a comma separated list of log Handler 
+# classes.  These handlers will be installed during VM startup.
+# Note that these classes must be on the system classpath.
+# By default we only configure a ConsoleHandler, which will only
+# show messages at the INFO and above levels.
+handlers = java.util.logging.ConsoleHandler
+
+# To also add the FileHandler, use the following line instead.
+#handlers = java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+# Default global logging level.
+# This specifies which kinds of events are logged across
+# all loggers.  For any given facility this global level
+# can be overriden by a facility specific level
+# Note that the ConsoleHandler also has a separate level
+# setting to limit messages printed to the console.
+.level = INFO
+
+############################################################
+# Handler specific properties.
+# Describes specific configuration info for Handlers.
+############################################################
+
+# Log file output is in target directory.
+java.util.logging.FileHandler.pattern = target/unit-tests-java-%u.log
+java.util.logging.FileHandler.limit = 50000
+java.util.logging.FileHandler.count = 1
+java.util.logging.FileHandler.formatter = java.util.logging.XMLFormatter
+
+# Limit the message that are printed on the console to WARNING and above.
+java.util.logging.ConsoleHandler.level = WARNING
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+# Example to customize the SimpleFormatter output format 
+# to print one-line log message like this:
+#     <level>: <log message> [<date/time>]
+#
+# java.util.logging.SimpleFormatter.format=%4$s: %5$s [%1$tc]%n
+
+############################################################
+# Facility specific properties.
+# Provides extra control for each logger.
+############################################################
+
+# [BAHIR-] don't flood build logs with superfluous Parquet INFO messages
+# they should be written to a file via FileHandler but they end up in the
+# build log anyhow irrespective of the ConsoleHandler log level
+# also see https://github.com/Parquet/parquet-mr/issues/425
+org.apache.parquet.hadoop.level=SEVERE

--- a/sql-streaming-mqtt/src/test/resources/logging.properties
+++ b/sql-streaming-mqtt/src/test/resources/logging.properties
@@ -16,10 +16,10 @@
 #
 
 ############################################################
-#  	Global properties
+# Global properties
 ############################################################
 
-# "handlers" specifies a comma separated list of log Handler 
+# "handlers" specifies a comma separated list of log Handler
 # classes.  These handlers will be installed during VM startup.
 # Note that these classes must be on the system classpath.
 # By default we only configure a ConsoleHandler, which will only
@@ -52,7 +52,7 @@ java.util.logging.FileHandler.formatter = java.util.logging.XMLFormatter
 java.util.logging.ConsoleHandler.level = WARNING
 java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
 
-# Example to customize the SimpleFormatter output format 
+# Example to customize the SimpleFormatter output format
 # to print one-line log message like this:
 #     <level>: <log message> [<date/time>]
 #


### PR DESCRIPTION
[BAHIR-84: Build log flooded with test log messages](https://issues.apache.org/jira/browse/BAHIR-84)

**Proposed Changes**

[Parquet-MR (1.7.0)](https://github.com/apache/parquet-mr/blob/parquet-1.7.0/parquet-common/src/main/java/org/apache/parquet/Log.java) uses Java Logging, not Log4j, so we ...
- add a new properties file: `sql-streaming-mqtt/src/test/resources/logging.properties`
- increase the logger threshold for `org.apache.parquet.hadoop.*` to `SEVERE` 
- add the the new `logging.properties` to the _maven-surefire-plugin_ and _scalatest-maven-plugin_ via the `java.util.logging.config.file` system property

**How was this change tested?**
- ran `mvn clean package`
- quick test with `mvn clean test -pl sql-streaming-mqtt -q`

**Result**
```
$ mvn clean test -pl sql-streaming-mqtt -q

-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Java HotSpot(TM) 64-Bit Server VM warning: ignoring option MaxPermSize=512m; support was removed in 8.0

Results :

Tests run: 0, Failures: 0, Errors: 0, Skipped: 0

Java HotSpot(TM) 64-Bit Server VM warning: ignoring option MaxPermSize=512m; support was removed in 8.0
Discovery starting.
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/Users/ckadner/.m2/repository/org/slf4j/slf4j-log4j12/1.7.16/slf4j-log4j12-1.7.16.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/Users/ckadner/.m2/repository/org/apache/activemq/activemq-all/5.13.3/activemq-all-5.13.3.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.slf4j.impl.Log4jLoggerFactory]
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
Discovery completed in 323 milliseconds.
Run starting. Expected test count is: 7
BasicMQTTSourceSuite:
- basic usage
- Send and receive 100 messages.
- no server up
- params not provided.
- Recovering offset from the last processed offset. !!! IGNORED !!!
StressTestMQTTSource:
- Send and receive messages of size 250MB. !!! IGNORED !!!
LocalMessageStoreSuite:
- serialize and deserialize
- Store and retreive
- Max offset stored
MQTTStreamSourceSuite:
Run completed in 21 seconds, 346 milliseconds.
Total number of tests run: 7
Suites: completed 5, aborted 0
Tests: succeeded 7, failed 0, canceled 0, ignored 2, pending 0
All tests passed.
```