### PR TITLE
Fixes for akka example

### DIFF
--- a/streaming-akka/examples/src/main/scala/org/apache/spark/examples/streaming/akka/ActorWordCount.scala
+++ b/streaming-akka/examples/src/main/scala/org/apache/spark/examples/streaming/akka/ActorWordCount.scala
@@ -62,11 +62,11 @@ class FeederActor extends Actor {
 
   def receive: Receive = {
     case SubscribeReceiver(receiverActor: ActorRef) =>
-      println("received subscribe from %s".format(receiverActor.toString))
+      println(s"received subscribe from ${receiverActor.toString}")
       receivers += receiverActor
 
     case UnsubscribeReceiver(receiverActor: ActorRef) =>
-      println("received unsubscribe from %s".format(receiverActor.toString))
+      println(s"received unsubscribe from ${receiverActor.toString}")
       receivers -= receiverActor
   }
 }
@@ -172,7 +172,7 @@ object ActorWordCount {
     val lines = AkkaUtils.createStream[String](
       ssc,
       Props(classOf[SampleActorReceiver[String]],
-        "akka.tcp://test@%s:%s/user/FeederActor".format(host, port.toInt)),
+        s"akka.tcp://test@$host:${port.toInt}/user/FeederActor"),
       "SampleReceiver")
 
     // compute wordcount

--- a/streaming-akka/examples/src/main/scala/org/apache/spark/examples/streaming/akka/ActorWordCount.scala
+++ b/streaming-akka/examples/src/main/scala/org/apache/spark/examples/streaming/akka/ActorWordCount.scala
@@ -18,7 +18,7 @@
 // scalastyle:off println
 package org.apache.spark.examples.streaming.akka
 
-import scala.collection.mutable.LinkedHashSet
+import scala.collection.mutable
 import scala.util.Random
 
 import akka.actor.{Props, _}
@@ -39,7 +39,7 @@ case class UnsubscribeReceiver(receiverActor: ActorRef)
 class FeederActor extends Actor {
 
   val rand = new Random()
-  val receivers = new LinkedHashSet[ActorRef]()
+  val receivers = new mutable.LinkedHashSet[ActorRef]()
 
   val strings: Array[String] = Array("words ", "may ", "count ")
 


### PR DESCRIPTION
Hi, 
I was looking at the streaming-akka example in Intellij IDE and it suggested some minor fixes:
- use string interpolation
- the mutable collection must be prefixed as mutable

Best regards,

Scott