### PR TITLE
[BAHIR-102] Initial support of Cloudant Query with python examples

### DIFF
--- a/sql-cloudant/README.md
+++ b/sql-cloudant/README.md
@@ -62,8 +62,8 @@ cloudant.protocol|https|protocol to use to transfer data: http or https
 cloudant.host||cloudant host url
 cloudant.username||cloudant userid
 cloudant.password||cloudant password
-cloudant.useQuery|false|When enabled, for query not using index or view, _find will be used instead of _all_docs, some query predicates will be driven into datastore. However, RDD partition is ONE during _find, so parallel loading is not achieved
-cloudant.queryLimit|25|the limit set onto _find query
+cloudant.useQuery|false|By default, _all_docs endpoint is used if configuration 'view' and 'index' (see below) are not set. When useQuery is enabled, _find endpoint will be used in place of _all_docs when query condition is not on primary key field (_id), so that query predicates may be driven into datastore. 
+cloudant.queryLimit|25|The maximum number of results returned when querying the _find endpoint.
 jsonstore.rdd.partitions|10|the number of partitions intent used to drive JsonStoreRDD loading query result in parallel. The actual number is calculated based on total rows returned and satisfying maxInPartition and minInPartition
 jsonstore.rdd.maxInPartition|-1|the max rows in a partition. -1 means unlimited
 jsonstore.rdd.minInPartition|10|the min rows in a partition.

--- a/sql-cloudant/README.md
+++ b/sql-cloudant/README.md
@@ -62,6 +62,8 @@ cloudant.protocol|https|protocol to use to transfer data: http or https
 cloudant.host||cloudant host url
 cloudant.username||cloudant userid
 cloudant.password||cloudant password
+cloudant.useQuery|false|When enabled, for query not using index or view, _find will be used instead of _all_docs, some query predicates will be driven into datastore. However, RDD partition is ONE during _find, so parallel loading is not achieved
+cloudant.queryLimit|25|the limit set onto _find query
 jsonstore.rdd.partitions|10|the number of partitions intent used to drive JsonStoreRDD loading query result in parallel. The actual number is calculated based on total rows returned and satisfying maxInPartition and minInPartition
 jsonstore.rdd.maxInPartition|-1|the max rows in a partition. -1 means unlimited
 jsonstore.rdd.minInPartition|10|the min rows in a partition.

--- a/sql-cloudant/examples/python/CloudantQuery.py
+++ b/sql-cloudant/examples/python/CloudantQuery.py
@@ -1,0 +1,65 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pprint
+from pyspark.sql import SparkSession
+
+# define cloudant related configuration
+# set protocol to http if needed, default value=https
+# config("cloudant.protocol","http")
+spark = SparkSession\
+    .builder\
+    .appName("Cloudant Spark SQL Example in Python using query")\
+    .config("cloudant.host","ACCOUNT.cloudant.com")\
+    .config("cloudant.username", "USERNAME")\
+    .config("cloudant.password","PASSWORD")\
+    .config("jsonstore.rdd.partitions", 8)\
+    .config("cloudant.useQuery", "true")\
+    .config("schemaSampleSize",1)\
+    .getOrCreate()
+
+
+spark.sql(" CREATE TEMPORARY VIEW airportTable1 USING org.apache.bahir.cloudant OPTIONS ( database 'n_airportcodemapping')")
+airportData = spark.sql("SELECT _id, airportName FROM airportTable1 WHERE airportName == 'Moscow' ")
+airportData.printSchema()
+print 'Total # of rows in airportData: ' + str(airportData.count())
+airportData.show()
+
+spark.sql(" CREATE TEMPORARY VIEW airportTable2 USING org.apache.bahir.cloudant OPTIONS ( database 'n_airportcodemapping')")
+airportData = spark.sql("SELECT _id, airportName FROM airportTable2 WHERE airportName > 'Moscow' ORDER BY _id")
+airportData.printSchema()
+print 'Total # of rows in airportData: ' + str(airportData.count())
+airportData.show()
+
+spark.sql(" CREATE TEMPORARY VIEW airportTable3 USING org.apache.bahir.cloudant OPTIONS ( database 'n_airportcodemapping')")
+airportData = spark.sql("SELECT _id, airportName FROM airportTable3 WHERE airportName > 'Moscow' AND  airportName < 'Sydney'  ORDER BY _id")
+airportData.printSchema()
+print 'Total # of rows in airportData: ' + str(airportData.count())
+airportData.show()
+
+spark.sql(" CREATE TEMPORARY VIEW flight1 USING org.apache.bahir.cloudant OPTIONS ( database 'n_flight')")
+flightData = spark.sql("SELECT flightSegmentId, economyClassBaseCost, numFirstClassSeats FROM flight1 WHERE economyClassBaseCost >=200 AND numFirstClassSeats<=10")
+flightData.printSchema()
+print 'Total # of rows in airportData: ' + str(flightData.count())
+flightData.show()
+
+spark.sql(" CREATE TEMPORARY VIEW flight2 USING org.apache.bahir.cloudant OPTIONS ( database 'n_flight')")
+flightData = spark.sql("SELECT flightSegmentId, scheduledDepartureTime, scheduledArrivalTime FROM flight2 WHERE scheduledDepartureTime >='2014-12-15T05:00:00.000Z' AND scheduledArrivalTime <='2014-12-15T11:04:00.000Z'")
+flightData.printSchema()
+print 'Total # of rows in airportData: ' + str(flightData.count())
+flightData.show()
+
+

--- a/sql-cloudant/examples/python/CloudantQueryDF.py
+++ b/sql-cloudant/examples/python/CloudantQueryDF.py
@@ -1,0 +1,61 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pprint
+from pyspark.sql import SparkSession
+
+# define cloudant related configuration
+# set protocol to http if needed, default value=https
+# config("cloudant.protocol","http")
+spark = SparkSession\
+    .builder\
+    .appName("Cloudant Spark SQL Example in Python using query")\
+    .config("cloudant.host","ACCOUNT.cloudant.com")\
+    .config("cloudant.username", "USERNAME")\
+    .config("cloudant.password","PASSWORD")\
+    .config("jsonstore.rdd.partitions", 8)\
+    .config("cloudant.useQuery", "true")\
+    .config("schemaSampleSize",1)\
+    .getOrCreate()
+
+
+# ***0. Loading dataframe from Cloudant db with one String field condition
+df = spark.read.load("n_airportcodemapping", "org.apache.bahir.cloudant")
+df.printSchema()
+df.filter(df.airportName == 'Moscow').select("_id",'airportName').show()
+
+
+# ***1. Loading dataframe from Cloudant db with one String field condition
+df = spark.read.load("n_airportcodemapping", "org.apache.bahir.cloudant")
+df.printSchema()
+df.filter(df.airportName > 'Moscow').select("_id",'airportName').show()
+
+# ***2. Loading dataframe from Cloudant db with two String field condition
+df = spark.read.load("n_airportcodemapping", "org.apache.bahir.cloudant")
+df.printSchema()
+df.filter(df.airportName > 'Moscow').filter(df.airportName < 'Sydney').select("_id",'airportName').show()
+
+# ***3. Loading dataframe from Cloudant db with two int field condition
+df = spark.read.load("n_flight", "org.apache.bahir.cloudant")
+df.printSchema()
+df.filter(df.economyClassBaseCost >= 200).filter(df.numFirstClassSeats <=10).select('flightSegmentId','scheduledDepartureTime', 'scheduledArrivalTime').show()
+
+# ***4. Loading dataframe from Cloudant db with two timestamp field condition
+df = spark.read.load("n_flight", "org.apache.bahir.cloudant")
+df.printSchema()
+df.filter(df.scheduledDepartureTime >= "2014-12-15T05:00:00.000Z").filter(df.scheduledArrivalTime <="2014-12-15T11:04:00.000Z").select('flightSegmentId','scheduledDepartureTime', 'scheduledArrivalTime').show()
+
+

--- a/sql-cloudant/src/main/resources/application.conf
+++ b/sql-cloudant/src/main/resources/application.conf
@@ -10,5 +10,7 @@ spark-sql {
     }
     cloudant = {
         protocol = https
+        useQuery = false
+        queryLimit = 25
     }
 }

--- a/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/common/JsonStoreRDD.scala
+++ b/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/common/JsonStoreRDD.scala
@@ -17,12 +17,13 @@
 package org.apache.bahir.cloudant.common
 
 import org.slf4j.LoggerFactory
+import play.api.libs.json.{JsNull, Json, JsString, JsValue}
 
 import org.apache.spark.Partition
 import org.apache.spark.SparkContext
 import org.apache.spark.TaskContext
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.sources.Filter
+import org.apache.spark.sql.sources._
 
 import org.apache.bahir.cloudant.CloudantConfig
 
@@ -31,9 +32,9 @@ import org.apache.bahir.cloudant.CloudantConfig
   * the limit rows returns and the skipped rows.
  */
 
-private[cloudant] class JsonStoreRDDPartition(val skip: Int, val limit: Int,
-    val idx: Int, val config: CloudantConfig,
-    val attrToFilters: Map[String, Array[Filter]])
+private[cloudant] class JsonStoreRDDPartition(val url: String, val skip: Int, val limit: Int,
+    val idx: Int, val config: CloudantConfig, val selector: JsValue, val fields: JsValue,
+    val queryUsed: Boolean)
     extends Partition with Serializable{
   val index = idx
 }
@@ -46,16 +47,15 @@ private[cloudant] class JsonStoreRDDPartition(val skip: Int, val limit: Int,
  *  and minInPartition / maxInPartition )
  *  maxRowsInPartition: -1 means unlimited
  */
-class JsonStoreRDD(sc: SparkContext, config: CloudantConfig,
-    url: String)(implicit requiredcolumns: Array[String] = null,
-    attrToFilters: Map[String, Array[Filter]] = null)
+class JsonStoreRDD(sc: SparkContext, config: CloudantConfig)
+    (implicit requiredcolumns: Array[String] = null,
+              filters: Array[Filter] = null)
   extends RDD[String](sc, Nil) {
 
-  lazy val totalRows = {
-      new JsonStoreDataAccess(config).getTotalRows(url)
-  }
-  lazy val totalPartition = {
-    if (totalRows == 0 || ! config.allowPartition() )  1
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  private def getTotalPartition(totalRows: Int, queryUsed: Boolean): Int = {
+    if (totalRows == 0 || ! config.allowPartition(queryUsed) )  1
     else if (totalRows < config.partitions * config.minInPartition) {
       val total = totalRows / config.minInPartition
       if (total == 0 ) {
@@ -76,7 +76,7 @@ class JsonStoreRDD(sc: SparkContext, config: CloudantConfig,
     }
   }
 
-  lazy val limitPerPartition = {
+  private def getLimitPerPartition(totalRows: Int, totalPartition: Int): Int = {
     val limit = totalRows/totalPartition
     if (totalRows % totalPartition != 0) {
       limit + 1
@@ -85,22 +85,115 @@ class JsonStoreRDD(sc: SparkContext, config: CloudantConfig,
     }
   }
 
+  private def convertToMangoJson(f: Filter): (String, JsValue) = {
+    val (op, value): (String, Any) = f match {
+      case EqualTo(attr, v) => ("$eq", v)
+      case GreaterThan(attr, v) => ("$gt", v)
+      case LessThan(attr, v) => ("$lt", v)
+      case GreaterThanOrEqual(attr, v) => ("$gte", v)
+      case LessThanOrEqual(attr, v) => ("$lte", v)
+      case _ => (null, null)
+    }
+    val convertedV: JsValue = {
+      // TODO Better handing of other types
+      if (value != null) {
+        value match {
+          case s: String => Json.toJson(s)
+          case l: Long => Json.toJson(l)
+          case d: Double => Json.toJson(d)
+          case i: Int => Json.toJson(i)
+          case b: Boolean => Json.toJson(b)
+          case t: java.sql.Timestamp => Json.toJson(t)
+          case a: Any => logger.debug(s"Ignore field:$name, cannot handle its datatype: $a"); null
+        }
+      } else null
+    }
+    (op, convertedV)
+  }
+
+  private def convertAttrToMangoJson(filters: Array[Filter]): Map[String, JsValue] = {
+    filters.map(af => convertToMangoJson(af))
+            .filter(x => x._2 != null)
+            .toMap
+  }
+
   override def getPartitions: Array[Partition] = {
-    val logger = LoggerFactory.getLogger(getClass)
+
+    logger.info("getPartitions:" + requiredcolumns + "," + filters)
+
+    val filterInterpreter = new FilterInterpreter(filters)
+    val origAttrToFilters = ( if (filters==null || filters.length==0) null
+                              else filterInterpreter.getFiltersForPostProcess(null))
+
+    val (selector, fields) : (JsValue, JsValue) = {
+      if (!config.queryEnabled() || origAttrToFilters == null) (null, null)
+      else {
+        val selectors: Map[String, Map[String, JsValue]] =
+          origAttrToFilters.transform( (name, attrFilters) => convertAttrToMangoJson(attrFilters))
+        val filteredSelectors = selectors.filter((t) => ! t._2.isEmpty)
+
+        if (! filteredSelectors.isEmpty) {
+          val queryColumns = (
+              if (requiredcolumns == null || requiredcolumns.size == 0) null
+              else Json.toJson(requiredcolumns))
+          (Json.toJson(filteredSelectors), queryColumns)
+        } else (null, null)
+      }
+    }
+
+    logger.info("calculated selector and fields:" + selector + "," + fields)
+
+    var searchField: String = {
+          if (origAttrToFilters ==null ) null
+          else if (filterInterpreter.containsFiltersFor(config.pkField)) {
+            config.pkField
+          } else {
+            filterInterpreter.firstField
+          }
+        }
+
+    val (min, minInclusive, max, maxInclusive) = filterInterpreter.getInfo(searchField)
+    val (url: String, pusheddown: Boolean, queryUsed: Boolean) = config.getRangeUrl(searchField,
+            min, minInclusive, max, maxInclusive, false, selector!=null)
+
+    implicit val postData : String = {
+      if (queryUsed) {
+        Json.stringify(Json.obj("selector" -> selector, "limit" -> 1))
+      } else {
+        null
+      }
+    }
+    val totalRows = new JsonStoreDataAccess(config).getTotalRows(url, queryUsed)
+    val totalPartition = getTotalPartition(totalRows, queryUsed)
+    val limitPerPartition = getLimitPerPartition(totalRows, totalPartition)
+
     logger.info(s"Partition config - total=$totalPartition, " +
         s"limit=$limitPerPartition for totalRows of $totalRows")
 
-    (0 until totalPartition).map(i => {
+   logger.info(s"Partition query info - url=$url, queryUsed=$queryUsed")
+
+   (0 until totalPartition).map(i => {
       val skip = i * limitPerPartition
-      new JsonStoreRDDPartition(skip, limitPerPartition, i, config,
-          attrToFilters).asInstanceOf[Partition]
+      new JsonStoreRDDPartition(url, skip, limitPerPartition, i,
+          config, selector, fields, queryUsed).asInstanceOf[Partition]
     }).toArray
   }
 
   override def compute(splitIn: Partition, context: TaskContext):
       Iterator[String] = {
     val myPartition = splitIn.asInstanceOf[JsonStoreRDDPartition]
+    implicit val postData : String = {
+      if (myPartition.queryUsed && myPartition.fields !=null) {
+        Json.stringify(Json.obj("selector" -> myPartition.selector, "fields" -> myPartition.fields,
+            "limit" -> myPartition.limit, "skip" -> myPartition.skip))
+      } else if (myPartition.queryUsed) {
+        Json.stringify(Json.obj("selector" -> myPartition.selector, "limit" -> myPartition.limit,
+            "skip" -> myPartition.skip))
+      } else {
+        null
+      }
+    }
     new JsonStoreDataAccess(myPartition.config).getIterator(myPartition.skip,
-        myPartition.limit, url)
+        myPartition.limit, myPartition.url)
   }
 }


### PR DESCRIPTION
All the existing examples (5 in scala, 3 in python) are tested successfully with and without Query enabled. 2 python examples are added with can drive into Query, and tested successfully with and without Query enabled. 