### PR TITLE
[BAHIR-152] Enforce License Header in Java Sources

### DIFF
--- a/dev/checkstyle-license-header.txt
+++ b/dev/checkstyle-license-header.txt
@@ -1,0 +1,16 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/dev/checkstyle.xml
+++ b/dev/checkstyle.xml
@@ -52,6 +52,12 @@
       <property name="file" value="dev/checkstyle-suppressions.xml"/>
     </module>
 
+    <!-- Checks for license header -->
+    <module name="Header">
+        <property name="headerFile" value="dev/checkstyle-license-header.txt"/>
+        <property name="fileExtensions" value="java"/>
+    </module>
+
     <!-- Checks for whitespace                               -->
     <!-- See http://checkstyle.sf.net/config_whitespace.html -->
     <module name="FileTabCharacter">


### PR DESCRIPTION
[BAHIR-152: License header not enforced for Java sources](https://issues.apache.org/jira/browse/BAHIR-152)

Add a `Header` rule to the `checkstyle` configuration to enforce proper
Apache license headers in `*.java` source files.

A similar `HeaderMatchesChecker` rule already exists in the `scalastyle`
configuration to enforce the license headers in `*.scala` source files.