### PR TITLE
[BAHIR-138] fix deprecated warnings in sql-cloudant

### DIFF
--- a/sql-cloudant/examples/src/main/scala/org/apache/spark/examples/sql/cloudant/CloudantStreaming.scala
+++ b/sql-cloudant/examples/src/main/scala/org/apache/spark/examples/sql/cloudant/CloudantStreaming.scala
@@ -35,7 +35,7 @@ object CloudantStreaming {
     val changes = ssc.receiverStream(new CloudantReceiver(sparkConf, Map(
       "cloudant.host" -> "examples.cloudant.com",
       "database" -> "sales")))
-
+    
     changes.foreachRDD((rdd: RDD[String], time: Time) => {
       // Get the singleton instance of SparkSession
       val spark = SparkSessionSingleton.getInstance(rdd.sparkContext.getConf)
@@ -62,16 +62,16 @@ object CloudantStreaming {
         }
 
         if (hasMonth) {
-          changesDataFrame.filter(changesDataFrame("month") >= "May").select("*").show()
-          changesDataFrame.createOrReplaceTempView("sales-in-may")
-          val airportCountsDataFrame =
+          changesDataFrame.filter(changesDataFrame("month") === "May").select("*").show(5)
+          changesDataFrame.createOrReplaceTempView("sales")
+          val salesInMayCountsDataFrame =
             spark.sql(
                 s"""
-                |select _id, rep, count(*) as total
-                |from sales-in-may
-                |group by month
+                |select rep, amount
+                |from sales
+                |where month = "May"
                 """.stripMargin)
-          airportCountsDataFrame.show()
+          salesInMayCountsDataFrame.show(5)
         }
       }
 

--- a/sql-cloudant/examples/src/main/scala/org/apache/spark/examples/sql/cloudant/CloudantStreaming.scala
+++ b/sql-cloudant/examples/src/main/scala/org/apache/spark/examples/sql/cloudant/CloudantStreaming.scala
@@ -35,7 +35,6 @@ object CloudantStreaming {
     val changes = ssc.receiverStream(new CloudantReceiver(sparkConf, Map(
       "cloudant.host" -> "examples.cloudant.com",
       "database" -> "sales")))
-    
     changes.foreachRDD((rdd: RDD[String], time: Time) => {
       // Get the singleton instance of SparkSession
       val spark = SparkSessionSingleton.getInstance(rdd.sparkContext.getConf)

--- a/sql-cloudant/examples/src/main/scala/org/apache/spark/examples/sql/cloudant/CloudantStreamingSelector.scala
+++ b/sql-cloudant/examples/src/main/scala/org/apache/spark/examples/sql/cloudant/CloudantStreamingSelector.scala
@@ -46,9 +46,11 @@ object CloudantStreamingSelector {
     changes.foreachRDD((rdd: RDD[String], time: Time) => {
       // Get the singleton instance of SQLContext
       val spark = SparkSessionSingleton.getInstance(rdd.sparkContext.getConf)
+      import spark.implicits._
+
       println(s"========= $time =========") // scalastyle:ignore
-      val changesDataFrame = spark.read.json(rdd)
-      if (!changesDataFrame.schema.isEmpty) {
+      val changesDataFrame = spark.read.json(rdd.toDS())
+      if (changesDataFrame.schema.nonEmpty) {
         changesDataFrame.select("*").show()
         batchAmount = changesDataFrame.groupBy().sum("amount").collect()(0).getLong(0)
         curSalesCount.getAndAdd(changesDataFrame.count())

--- a/sql-cloudant/examples/src/main/scala/org/apache/spark/examples/sql/cloudant/CloudantStreamingSelector.scala
+++ b/sql-cloudant/examples/src/main/scala/org/apache/spark/examples/sql/cloudant/CloudantStreamingSelector.scala
@@ -28,7 +28,8 @@ import org.apache.bahir.cloudant.CloudantReceiver
 
 object CloudantStreamingSelector {
   def main(args: Array[String]) {
-    val sparkConf = new SparkConf().setAppName("Cloudant Spark SQL External Datasource in Scala")
+    val sparkConf = new SparkConf().setMaster("local[*]")
+      .setAppName("Cloudant Spark SQL External Datasource in Scala")
 
     // Create the context with a 10 seconds batch size
     val ssc = new StreamingContext(sparkConf, Seconds(10))
@@ -37,9 +38,7 @@ object CloudantStreamingSelector {
     var batchAmount = 0L
 
     val changes = ssc.receiverStream(new CloudantReceiver(sparkConf, Map(
-      "cloudant.host" -> "ACCOUNT.cloudant.com",
-      "cloudant.username" -> "USERNAME",
-      "cloudant.password" -> "PASSWORD",
+      "cloudant.host" -> "examples.cloudant.com",
       "database" -> "sales",
       "selector" -> "{\"month\":\"May\", \"rep\":\"John\"}")))
 
@@ -57,7 +56,9 @@ object CloudantStreamingSelector {
         curTotalAmount.getAndAdd(batchAmount)
         println("Current sales count:" + curSalesCount)// scalastyle:ignore
         println("Current total amount:" + curTotalAmount)// scalastyle:ignore
-        }
+      } else {
+        ssc.stop()
+      }
     })
 
     ssc.start()

--- a/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/CloudantReceiver.scala
+++ b/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/CloudantReceiver.scala
@@ -74,7 +74,9 @@ class CloudantReceiver(sparkConf: SparkConf, cloudantParams: Map[String, String]
             var doc = ""
             if(jsonDoc != null) {
               doc = Json.stringify(jsonDoc)
-              store(doc)
+              if(!isStopped() && doc.nonEmpty) {
+                store(doc)
+              }
             }
           }
         })

--- a/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/DefaultSource.scala
+++ b/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/DefaultSource.scala
@@ -37,6 +37,8 @@ case class CloudantReadWriteRelation (config: CloudantConfig,
 
     implicit lazy val logger: Logger = LoggerFactory.getLogger(getClass)
 
+    import sqlContext.implicits._
+
     def buildScan(requiredColumns: Array[String],
                 filters: Array[Filter]): RDD[Row] = {
       val colsLength = requiredColumns.length
@@ -56,7 +58,7 @@ case class CloudantReadWriteRelation (config: CloudantConfig,
 
         logger.info("buildScan:" + columns + "," + origFilters)
         val cloudantRDD = new JsonStoreRDD(sqlContext.sparkContext, config)
-        val df = sqlContext.read.json(cloudantRDD)
+        val df = sqlContext.read.json(cloudantRDD.toDS())
         if (colsLength > 1) {
           val colsExceptCol0 = for (i <- 1 until colsLength) yield requiredColumns(i)
           df.select(requiredColumns(0), colsExceptCol0: _*).rdd
@@ -98,6 +100,8 @@ class DefaultSource extends RelationProvider
                        parameters: Map[String, String],
                        inSchema: StructType) = {
 
+      import sqlContext.implicits._
+
       val config: CloudantConfig = JsonStoreConfigManager.getConfig(sqlContext, parameters)
 
       var dataFrame: DataFrame = null
@@ -112,24 +116,23 @@ class DefaultSource extends RelationProvider
             config.viewName == null
             && config.indexName == null) {
             val cloudantRDD = new JsonStoreRDD(sqlContext.sparkContext, config)
-            dataFrame = sqlContext.read.json(cloudantRDD)
+            dataFrame = sqlContext.read.json(cloudantRDD.toDS())
             dataFrame
           } else {
             val dataAccess = new JsonStoreDataAccess(config)
             val aRDD = sqlContext.sparkContext.parallelize(
                 dataAccess.getMany(config.getSchemaSampleSize))
-            sqlContext.read.json(aRDD)
+            sqlContext.read.json(aRDD.toDS())
           }
           df.schema
         } else {
           /* Create a streaming context to handle transforming docs in
           * larger databases into Spark datasets
           */
+          val changesConfig = config.asInstanceOf[CloudantChangesConfig]
           val ssc = new StreamingContext(sqlContext.sparkContext, Seconds(10))
 
-          val changesConfig = config.asInstanceOf[CloudantChangesConfig]
-          val changes = ssc.receiverStream(
-            new ChangesReceiver(changesConfig))
+          val changes = ssc.receiverStream(new ChangesReceiver(changesConfig))
           changes.persist(changesConfig.getStorageLevelForStreaming)
 
           // Global RDD that's created from union of all RDDs
@@ -149,7 +152,7 @@ class DefaultSource extends RelationProvider
               }
             } else {
               // Convert final global RDD[String] to DataFrame
-              dataFrame = sqlContext.sparkSession.read.json(globalRDD)
+              dataFrame = sqlContext.sparkSession.read.json(globalRDD.toDS())
               ssc.stop(stopSparkContext = false, stopGracefully = false)
             }
           })

--- a/sql-cloudant/src/test/scala/org/apache/bahir/cloudant/ClientSparkFunSuite.scala
+++ b/sql-cloudant/src/test/scala/org/apache/bahir/cloudant/ClientSparkFunSuite.scala
@@ -81,10 +81,10 @@ class ClientSparkFunSuite extends SparkFunSuite with BeforeAndAfter {
     // insert docs and design docs from JSON flat files
     for (dbName: String <- TestUtils.testDatabasesList) {
       val db = client.database(dbName, true)
-      val jsonFilePath = System.getProperty("user.dir") +
-        "/src/test/resources/json-files/" + dbName + ".json"
-      if (new File(jsonFilePath).exists()) {
-        val jsonFileArray = new Gson().fromJson(new FileReader(jsonFilePath), classOf[JsonArray])
+      val jsonFilePath = getClass.getResource("/json-files/" + dbName + ".json")
+      if (jsonFilePath != null && new File(jsonFilePath.getFile).exists()) {
+        val jsonFileArray = new Gson().fromJson(new FileReader(jsonFilePath.getFile),
+          classOf[JsonArray])
         val listOfObjects = new util.ArrayList[JsonObject]
         if (jsonFileArray != null) {
           var i = 0


### PR DESCRIPTION
_What_
Fix warnings in `DefaultSource` class, and in `CloudantStreaming` and `CloudantStreamingSelector` examples. 

_How_
- Imported `spark.implicits._` to convert Spark RDD to Dataset
- Replaced deprecated `json(RDD[String])` with `json(Dataset[String])`

Improved streaming examples:
- Replaced `registerTempTable` with preferred `createOrReplaceTempView`
- Replaced `!isEmpty` with `nonEmpty`
- Use an accessible `sales` database so users can run the example without any setup
- Fixed error message when stopping tests by adding logic to streaming receiver to not store documents in Spark memory when stream has stopped

See [BAHIR-138](https://issues.apache.org/jira/browse/BAHIR-138)