### PR TITLE
[BAHIR-137] _changes feed receiver improvements

### DIFF
--- a/sql-cloudant/README.md
+++ b/sql-cloudant/README.md
@@ -65,7 +65,7 @@ cloudant.username| |cloudant userid
 cloudant.password| |cloudant password
 cloudant.useQuery|false|by default, `_all_docs` endpoint is used if configuration 'view' and 'index' (see below) are not set. When useQuery is enabled, `_find` endpoint will be used in place of `_all_docs` when query condition is not on primary key field (_id), so that query predicates may be driven into datastore. 
 cloudant.queryLimit|25|the maximum number of results returned when querying the `_find` endpoint.
-storageLevel|MEMORY_ONLY|the storage level for persisting Spark RDDs during load when `cloudant.endpoint` is set to `_changes`.  See [RDD Persistence section](https://spark.apache.org/docs/latest/programming-guide.html#rdd-persistence) in Spark's Progamming Guide for all available storage level options.
+cloudant.storageLevel|MEMORY_ONLY|the storage level for persisting Spark RDDs during load when `cloudant.endpoint` is set to `_changes`.  See [RDD Persistence section](https://spark.apache.org/docs/latest/programming-guide.html#rdd-persistence) in Spark's Progamming Guide for all available storage level options.
 cloudant.timeout|60000|stop the response after waiting the defined number of milliseconds for data.  Only supported with `changes` endpoint.
 jsonstore.rdd.partitions|10|the number of partitions intent used to drive JsonStoreRDD loading query result in parallel. The actual number is calculated based on total rows returned and satisfying maxInPartition and minInPartition. Only supported with `_all_docs` endpoint.
 jsonstore.rdd.maxInPartition|-1|the max rows in a partition. -1 means unlimited

--- a/sql-cloudant/README.md
+++ b/sql-cloudant/README.md
@@ -57,6 +57,7 @@ Default values are defined in [here](src/main/resources/application.conf).
 
 Name | Default | Meaning
 --- |:---:| ---
+cloudant.batchInterval|8|number of seconds to set for streaming all documents from `_changes` endpoint into Spark dataframe.  See [Setting the right batch interval](https://spark.apache.org/docs/latest/streaming-programming-guide.html#setting-the-right-batch-interval) for tuning this value.
 cloudant.endpoint|`_all_docs`|endpoint for RelationProvider when loading data from Cloudant to DataFrames or SQL temporary tables. Select between the Cloudant `_all_docs` or `_changes` API endpoint.  See **Note** below for differences between endpoints.
 cloudant.protocol|https|protocol to use to transfer data: http or https
 cloudant.host| |cloudant host url
@@ -64,7 +65,7 @@ cloudant.username| |cloudant userid
 cloudant.password| |cloudant password
 cloudant.useQuery|false|by default, `_all_docs` endpoint is used if configuration 'view' and 'index' (see below) are not set. When useQuery is enabled, `_find` endpoint will be used in place of `_all_docs` when query condition is not on primary key field (_id), so that query predicates may be driven into datastore. 
 cloudant.queryLimit|25|the maximum number of results returned when querying the `_find` endpoint.
-cloudant.storageLevel|MEMORY_ONLY|the storage level for persisting Spark RDDs during load when `cloudant.endpoint` is set to `_changes`.  See [RDD Persistence section](https://spark.apache.org/docs/latest/programming-guide.html#rdd-persistence) in Spark's Progamming Guide for all available storage level options.
+storageLevel|MEMORY_ONLY|the storage level for persisting Spark RDDs during load when `cloudant.endpoint` is set to `_changes`.  See [RDD Persistence section](https://spark.apache.org/docs/latest/programming-guide.html#rdd-persistence) in Spark's Progamming Guide for all available storage level options.
 cloudant.timeout|60000|stop the response after waiting the defined number of milliseconds for data.  Only supported with `changes` endpoint.
 jsonstore.rdd.partitions|10|the number of partitions intent used to drive JsonStoreRDD loading query result in parallel. The actual number is calculated based on total rows returned and satisfying maxInPartition and minInPartition. Only supported with `_all_docs` endpoint.
 jsonstore.rdd.maxInPartition|-1|the max rows in a partition. -1 means unlimited

--- a/sql-cloudant/src/main/resources/application.conf
+++ b/sql-cloudant/src/main/resources/application.conf
@@ -9,6 +9,7 @@ spark-sql {
         requestTimeout = 900000
     }
     cloudant = {
+        batchInterval = 8
         endpoint = "_all_docs"
         protocol = https
         useQuery = false

--- a/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/CloudantChangesConfig.scala
+++ b/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/CloudantChangesConfig.scala
@@ -27,12 +27,16 @@ class CloudantChangesConfig(protocol: String, host: String, dbName: String,
                             bulkSize: Int, schemaSampleSize: Int,
                             createDBOnSave: Boolean, endpoint: String, selector: String,
                             timeout: Int, storageLevel: StorageLevel, useQuery: Boolean,
-                            queryLimit: Int)
+                            queryLimit: Int, batchInterval: Int)
   extends CloudantConfig(protocol, host, dbName, indexName, viewName)(username, password,
     partitions, maxInPartition, minInPartition, requestTimeout, bulkSize, schemaSampleSize,
     createDBOnSave, endpoint, useQuery, queryLimit) {
 
   override val defaultIndex: String = endpoint
+
+  def getBatchInterval : Int = {
+    batchInterval
+  }
 
   def getSelector : String = {
     if (selector != null && !selector.isEmpty) {

--- a/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/CloudantChangesConfig.scala
+++ b/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/CloudantChangesConfig.scala
@@ -84,3 +84,8 @@ class CloudantChangesConfig(protocol: String, host: String, dbName: String,
     dbUrl + "/" + JsonStoreConfigManager.ALL_DOCS_INDEX
   }
 }
+
+object CloudantChangesConfig {
+  // Error message from internal _changes receiver
+  var receiverErrorMsg: String = ""
+}

--- a/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/DefaultSource.scala
+++ b/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/DefaultSource.scala
@@ -159,7 +159,13 @@ class DefaultSource extends RelationProvider
           // run streaming until all docs from continuous feed are received
           ssc.awaitTermination
 
-          dataFrame.schema
+          if(dataFrame.schema.nonEmpty) {
+            dataFrame.schema
+          } else {
+            throw new CloudantException("Final schema for _changes feed is empty. " +
+              "This may be due to the streaming batch size. Please increase the " +
+              "cloudant.batchInterval option and try again.")
+          }
         }
       }
       CloudantReadWriteRelation(config, schema, dataFrame)(sqlContext)

--- a/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/DefaultSource.scala
+++ b/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/DefaultSource.scala
@@ -125,9 +125,10 @@ class DefaultSource extends RelationProvider
           /* Create a streaming context to handle transforming docs in
           * larger databases into Spark datasets
           */
-          val ssc = new StreamingContext(sqlContext.sparkContext, Seconds(8))
-
           val changesConfig = config.asInstanceOf[CloudantChangesConfig]
+          val ssc = new StreamingContext(sqlContext.sparkContext,
+            Seconds(changesConfig.getBatchInterval))
+
           val changes = ssc.receiverStream(
             new ChangesReceiver(changesConfig))
           changes.persist(changesConfig.getStorageLevelForStreaming)

--- a/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/DefaultSource.scala
+++ b/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/DefaultSource.scala
@@ -162,9 +162,7 @@ class DefaultSource extends RelationProvider
           if(dataFrame.schema.nonEmpty) {
             dataFrame.schema
           } else {
-            throw new CloudantException("Final schema for _changes feed is empty. " +
-              "This may be due to the streaming batch size. Please increase the " +
-              "cloudant.batchInterval option and try again.")
+            throw new CloudantException(CloudantChangesConfig.receiverErrorMsg)
           }
         }
       }

--- a/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/common/JsonStoreConfigManager.scala
+++ b/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/common/JsonStoreConfigManager.scala
@@ -18,8 +18,8 @@ package org.apache.bahir.cloudant.common
 
 import com.typesafe.config.ConfigFactory
 
-import org.apache.spark.sql.SQLContext
 import org.apache.spark.SparkConf
+import org.apache.spark.sql.SQLContext
 import org.apache.spark.storage.StorageLevel
 
 import org.apache.bahir.cloudant.{CloudantChangesConfig, CloudantConfig}
@@ -35,6 +35,7 @@ object JsonStoreConfigManager {
   private val CLOUDANT_PASSWORD_CONFIG = "cloudant.password"
   private val CLOUDANT_PROTOCOL_CONFIG = "cloudant.protocol"
   private val CLOUDANT_API_ENDPOINT = "cloudant.endpoint"
+  private val CLOUDANT_STREAMING_BATCH_INTERVAL = "cloudant.batchInterval"
   private val STORAGE_LEVEL_FOR_CHANGES_INDEX = "cloudant.storageLevel"
   private val CLOUDANT_CHANGES_TIMEOUT = "cloudant.timeout"
   private val USE_QUERY_CONFIG = "cloudant.useQuery"
@@ -173,6 +174,7 @@ object JsonStoreConfigManager {
     implicit val storageLevel = getStorageLevel(
       sparkConf, parameters, STORAGE_LEVEL_FOR_CHANGES_INDEX)
     implicit val timeout = getInt(sparkConf, parameters, CLOUDANT_CHANGES_TIMEOUT)
+    implicit val batchInterval = getInt(sparkConf, parameters, CLOUDANT_STREAMING_BATCH_INTERVAL)
 
     implicit val useQuery = getBool(sparkConf, parameters, USE_QUERY_CONFIG)
     implicit val queryLimit = getInt(sparkConf, parameters, QUERY_LIMIT_CONFIG)
@@ -197,7 +199,7 @@ object JsonStoreConfigManager {
       new CloudantChangesConfig(protocol, host, dbName, indexName,
         viewName) (user, passwd, total, max, min, requestTimeout,
         bulkSize, schemaSampleSize, createDBOnSave, endpoint, selector,
-        timeout, storageLevel, useQuery, queryLimit)
+        timeout, storageLevel, useQuery, queryLimit, batchInterval)
     } else {
       throw new CloudantException(s"spark.$CLOUDANT_API_ENDPOINT parameter " +
         s"is invalid. Please supply the valid option '" + ALL_DOCS_INDEX + "' or '" +

--- a/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/internal/ChangesReceiver.scala
+++ b/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/internal/ChangesReceiver.scala
@@ -70,9 +70,10 @@ class ChangesReceiver(config: CloudantChangesConfig)
         }
       } else {
         val status = headers.getOrElse("Status", IndexedSeq.empty)
-        val errorMsg = "Error retrieving _changes feed " + config.getDbname + ": " + status(0)
+        val errorMsg = "Error retrieving _changes feed data from database " +
+          "'" + config.getDbname + "': " + status(0)
         reportError(errorMsg, new CloudantException(errorMsg))
-        stop(errorMsg)
+        CloudantChangesConfig.receiverErrorMsg = errorMsg
       }
     })
   }

--- a/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/internal/ChangesReceiver.scala
+++ b/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/internal/ChangesReceiver.scala
@@ -72,6 +72,7 @@ class ChangesReceiver(config: CloudantChangesConfig)
         val status = headers.getOrElse("Status", IndexedSeq.empty)
         val errorMsg = "Error retrieving _changes feed " + config.getDbname + ": " + status(0)
         reportError(errorMsg, new CloudantException(errorMsg))
+        stop(errorMsg)
       }
     })
   }

--- a/sql-cloudant/src/test/scala/org/apache/bahir/cloudant/CloudantOptionSuite.scala
+++ b/sql-cloudant/src/test/scala/org/apache/bahir/cloudant/CloudantOptionSuite.scala
@@ -86,4 +86,20 @@ class CloudantOptionSuite extends ClientSparkFunSuite with BeforeAndAfter {
     assert(thrown.getMessage === s"Cloudant database name is empty. " +
       s"Please supply the required value.")
   }
+
+  testIfEnabled("incorrect password throws an error message for changes receiver") {
+    spark = SparkSession.builder().config(conf)
+      .config("cloudant.protocol", TestUtils.getProtocol)
+      .config("cloudant.host", TestUtils.getHost)
+      .config("cloudant.username", TestUtils.getUsername)
+      .config("cloudant.password", TestUtils.getPassword.concat("a"))
+      .config("cloudant.endpoint", "_changes")
+      .getOrCreate()
+
+    val thrown = intercept[CloudantException] {
+      spark.read.format("org.apache.bahir.cloudant").load("n_flight")
+    }
+    assert(thrown.getMessage === s"Error retrieving _changes feed data" +
+      s" from database 'n_flight': HTTP/1.1 401 Unauthorized")
+  }
 }


### PR DESCRIPTION
_What_
- Added batchInterval option for tuning `_changes` receiver’s streaming batch interval
- Throw `CloudantException` if the final schema for the _changes receiver is empty
- Call stop method in streaming receiver when there’s an error

See [BAHIR-137](https://issues.apache.org/jira/browse/BAHIR-137)