### PR TITLE
[BAHIR-154] Refactor sql-cloudant to use Cloudant's java-cloudant features

### DIFF
--- a/sql-cloudant/README.md
+++ b/sql-cloudant/README.md
@@ -63,6 +63,7 @@ cloudant.protocol|https|protocol to use to transfer data: http or https
 cloudant.host| |cloudant host url
 cloudant.username| |cloudant userid
 cloudant.password| |cloudant password
+cloudant.numberOfRetries|3| number of times to replay a request that received a 429 `Too Many Requests` response
 cloudant.useQuery|false|by default, `_all_docs` endpoint is used if configuration 'view' and 'index' (see below) are not set. When useQuery is enabled, `_find` endpoint will be used in place of `_all_docs` when query condition is not on primary key field (_id), so that query predicates may be driven into datastore. 
 cloudant.queryLimit|25|the maximum number of results returned when querying the `_find` endpoint.
 cloudant.storageLevel|MEMORY_ONLY|the storage level for persisting Spark RDDs during load when `cloudant.endpoint` is set to `_changes`.  See [RDD Persistence section](https://spark.apache.org/docs/latest/programming-guide.html#rdd-persistence) in Spark's Progamming Guide for all available storage level options.

--- a/sql-cloudant/pom.xml
+++ b/sql-cloudant/pom.xml
@@ -41,6 +41,11 @@
       <version>2.11.0</version>
     </dependency>
     <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+      <version>3.9.0</version>
+    </dependency>
+    <dependency>
       <groupId>com.typesafe.play</groupId>
       <artifactId>play-json_${scala.binary.version}</artifactId>
     </dependency>

--- a/sql-cloudant/pom.xml
+++ b/sql-cloudant/pom.xml
@@ -36,6 +36,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.cloudant</groupId>
+      <artifactId>cloudant-client</artifactId>
+      <version>2.11.0</version>
+    </dependency>
+    <dependency>
       <groupId>com.typesafe.play</groupId>
       <artifactId>play-json_${scala.binary.version}</artifactId>
     </dependency>
@@ -104,12 +109,6 @@
     <dependency>
       <groupId>org.scalacheck</groupId>
       <artifactId>scalacheck_${scala.binary.version}</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.cloudant</groupId>
-      <artifactId>cloudant-client</artifactId>
-      <version>2.11.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/sql-cloudant/pom.xml
+++ b/sql-cloudant/pom.xml
@@ -46,18 +46,9 @@
       <version>3.9.0</version>
     </dependency>
     <dependency>
-      <groupId>com.typesafe.play</groupId>
-      <artifactId>play-json_${scala.binary.version}</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.typesafe</groupId>
       <artifactId>config</artifactId>
       <version>1.3.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.joda</groupId>
-      <artifactId>joda-convert</artifactId>
-      <version>1.8.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/sql-cloudant/src/main/resources/application.conf
+++ b/sql-cloudant/src/main/resources/application.conf
@@ -11,6 +11,7 @@ spark-sql {
     cloudant = {
         batchInterval = 8
         endpoint = "_all_docs"
+        numberOfRetries = 3
         protocol = https
         useQuery = false
         queryLimit = 25

--- a/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/CloudantChangesConfig.scala
+++ b/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/CloudantChangesConfig.scala
@@ -27,10 +27,10 @@ class CloudantChangesConfig(protocol: String, host: String, dbName: String,
                             bulkSize: Int, schemaSampleSize: Int,
                             createDBOnSave: Boolean, endpoint: String, selector: String,
                             timeout: Int, storageLevel: StorageLevel, useQuery: Boolean,
-                            queryLimit: Int, batchInterval: Int)
+                            queryLimit: Int, batchInterval: Int, numberOfRetries: Int)
   extends CloudantConfig(protocol, host, dbName, indexName, viewName)(username, password,
     partitions, maxInPartition, minInPartition, requestTimeout, bulkSize, schemaSampleSize,
-    createDBOnSave, endpoint, useQuery, queryLimit) {
+    createDBOnSave, endpoint, useQuery, queryLimit, numberOfRetries) {
 
   override val defaultIndex: String = endpoint
 

--- a/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/CloudantChangesConfig.scala
+++ b/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/CloudantChangesConfig.scala
@@ -42,9 +42,14 @@ class CloudantChangesConfig(protocol: String, host: String, dbName: String,
     if (selector != null && !selector.isEmpty) {
       selector
     } else {
-      // Exclude design docs and deleted=true docs
-      "{ \"_id\": { \"$regex\": \"^(?!_design/)\" }, " +
-        "\"_deleted\": { \"$exists\": false } }"
+      val version = getClient.serverVersion
+      if (version.matches("1.*")) {
+        null
+      } else {
+        // Exclude design docs and deleted=true docs
+        "{ \"_id\": { \"$regex\": \"^(?!_design/)\" }, " +
+          "\"_deleted\": { \"$exists\": false } }"
+      }
     }
   }
 

--- a/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/common/FilterUtil.scala
+++ b/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/common/FilterUtil.scala
@@ -16,11 +16,10 @@
  */
 package org.apache.bahir.cloudant.common
 
+import com.google.gson.JsonObject
 import org.slf4j.LoggerFactory
-import play.api.libs.json.{JsObject, JsString, JsValue}
 
 import org.apache.spark.sql.sources._
-
 
 /**
  * Only handles the following filter condition
@@ -118,11 +117,11 @@ class FilterInterpreter(origFilters: Array[Filter]) {
  */
 class FilterUtil(filters: Map[String, Array[Filter]]) {
   private val logger = LoggerFactory.getLogger(getClass)
-  def apply(implicit r: JsValue = null): Boolean = {
+  def apply(implicit r: JsonObject = null): Boolean = {
     if (r == null) return true
     val satisfied = filters.forall({
       case (attr, filters) =>
-        val field = JsonUtil.getField(r, attr).getOrElse(null)
+        val field = JsonUtil.getField(r, attr).orNull
         if (field == null) {
           logger.debug(s"field $attr not exisit:$r")
           false
@@ -136,12 +135,10 @@ class FilterUtil(filters: Map[String, Array[Filter]]) {
 
 
 object FilterDDocs {
-  def filter(row: JsValue): Boolean = {
+  def filter(row: JsonObject): Boolean = {
     if (row == null) return true
-    val id : String = if (row.as[JsObject].keys.contains("_id")) {
-      JsonUtil.getField(row, "_id").orNull.as[JsString].value
-    } else if (row.as[JsObject].keys.contains("id")) {
-      JsonUtil.getField(row, "id").orNull.as[JsString].value
+    val id : String = if (row.has("_id")) {
+      row.get("_id").getAsString
     } else {
       null
     }

--- a/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/common/JsonStoreConfigManager.scala
+++ b/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/common/JsonStoreConfigManager.scala
@@ -162,22 +162,23 @@ object JsonStoreConfigManager {
 
   def getConfig (sparkConf: SparkConf, parameters: Map[String, String]): CloudantConfig = {
 
-    implicit val total = getInt(sparkConf, parameters, PARTITION_CONFIG)
-    implicit val max = getInt(sparkConf, parameters, MAX_IN_PARTITION_CONFIG)
-    implicit val min = getInt(sparkConf, parameters, MIN_IN_PARTITION_CONFIG)
-    implicit val requestTimeout = getLong(sparkConf, parameters, REQUEST_TIMEOUT_CONFIG)
-    implicit val bulkSize = getInt(sparkConf, parameters, BULK_SIZE_CONFIG)
-    implicit val schemaSampleSize = getInt(sparkConf, parameters, SCHEMA_SAMPLE_SIZE_CONFIG)
-    implicit val createDBOnSave = getBool(sparkConf, parameters, CREATE_DB_ON_SAVE_CONFIG)
-    implicit val endpoint = getString(sparkConf, parameters, CLOUDANT_API_ENDPOINT)
-    implicit val selector = getString(sparkConf, parameters, FILTER_SELECTOR)
-    implicit val storageLevel = getStorageLevel(
+    implicit val total: Int = getInt(sparkConf, parameters, PARTITION_CONFIG)
+    implicit val max: Int = getInt(sparkConf, parameters, MAX_IN_PARTITION_CONFIG)
+    implicit val min: Int = getInt(sparkConf, parameters, MIN_IN_PARTITION_CONFIG)
+    implicit val requestTimeout: Long = getLong(sparkConf, parameters, REQUEST_TIMEOUT_CONFIG)
+    implicit val bulkSize: Int = getInt(sparkConf, parameters, BULK_SIZE_CONFIG)
+    implicit val schemaSampleSize: Int = getInt(sparkConf, parameters, SCHEMA_SAMPLE_SIZE_CONFIG)
+    implicit val createDBOnSave: Boolean = getBool(sparkConf, parameters, CREATE_DB_ON_SAVE_CONFIG)
+    implicit val endpoint: String = getString(sparkConf, parameters, CLOUDANT_API_ENDPOINT)
+    implicit val selector: String = getString(sparkConf, parameters, FILTER_SELECTOR)
+    implicit val storageLevel: StorageLevel = getStorageLevel(
       sparkConf, parameters, STORAGE_LEVEL_FOR_CHANGES_INDEX)
-    implicit val timeout = getInt(sparkConf, parameters, CLOUDANT_CHANGES_TIMEOUT)
-    implicit val batchInterval = getInt(sparkConf, parameters, CLOUDANT_STREAMING_BATCH_INTERVAL)
+    implicit val timeout: Int = getInt(sparkConf, parameters, CLOUDANT_CHANGES_TIMEOUT)
+    implicit val batchInterval: Int = getInt(
+      sparkConf, parameters, CLOUDANT_STREAMING_BATCH_INTERVAL)
 
-    implicit val useQuery = getBool(sparkConf, parameters, USE_QUERY_CONFIG)
-    implicit val queryLimit = getInt(sparkConf, parameters, QUERY_LIMIT_CONFIG)
+    implicit val useQuery: Boolean = getBool(sparkConf, parameters, USE_QUERY_CONFIG)
+    implicit val queryLimit: Int = getInt(sparkConf, parameters, QUERY_LIMIT_CONFIG)
 
     val dbName = parameters.getOrElse("database", parameters.getOrElse("path",
       throw new CloudantException(s"Cloudant database name is empty. " +

--- a/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/common/JsonStoreDataAccess.scala
+++ b/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/common/JsonStoreDataAccess.scala
@@ -63,21 +63,21 @@ class JsonStoreDataAccess (config: CloudantConfig)  {
   }
 
   def getTotalRows(url: String, queryUsed: Boolean)
-      (implicit postData: String = null): Int = {
-      if (queryUsed) config.queryLimit // Query can not retrieve total row now.
-      else {
-        val totalUrl = config.getTotalUrl(url)
-         this.getQueryResult[Int](totalUrl,
-           { result => config.getResultTotalRows(result)})
-      }
+                  (implicit postData: String = null): Int = {
+    if (queryUsed) config.queryLimit // Query can not retrieve total row now.
+    else {
+      val totalUrl = config.getTotalUrl(url)
+      this.getQueryResult[Int](totalUrl,
+        { result => config.getResultCount(result)})
+    }
   }
 
-  private def processAll (result: String)
+  private def processAll(result: String)
       (implicit columns: Array[String],
       postData: String = null) = {
     logger.debug(s"processAll:$result, columns:$columns")
-    var rows = config.getRows(result, postData != null )
-    if (config.viewName == null && postData == null) {
+    var rows = config.getRows(result, postData != null)
+    if (config.viewPath == null && postData == null) {
       // filter design docs
       rows = rows.filter(r => FilterDDocs.filter(r))
     }

--- a/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/common/JsonStoreRDD.scala
+++ b/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/common/JsonStoreRDD.scala
@@ -109,8 +109,8 @@ class JsonStoreRDD(sc: SparkContext, config: CloudantConfig)
       // TODO Better handing of other types
       if (value != null) {
         value match {
-          case s: String => parser.parse(s)// Json.toJson(s)
-          case l: Long => parser.parse(l.toString) // Json.toJson(l)
+          case s: String => parser.parse(s)
+          case l: Long => parser.parse(l.toString)
           case d: Double => parser.parse(d.toString)
           case i: Int => parser.parse(i.toString)
           case b: Boolean => parser.parse(b.toString)
@@ -182,7 +182,6 @@ class JsonStoreRDD(sc: SparkContext, config: CloudantConfig)
         jsonSelector.addProperty("selector", selector.toString)
         jsonSelector.addProperty("limit", 1)
         jsonSelector.toString
-        // Json.stringify(Json.obj("selector" -> selector, "limit" -> 1))
       } else {
         null
       }
@@ -209,19 +208,13 @@ class JsonStoreRDD(sc: SparkContext, config: CloudantConfig)
     val myPartition = splitIn.asInstanceOf[JsonStoreRDDPartition]
     implicit val postData : String = {
       val jsonObject = new JsonObject
+      jsonObject.add("selector", myPartition.selector)
+      jsonObject.addProperty("skip", myPartition.skip)
       if (myPartition.queryUsed && myPartition.fields != null) {
-        // Json.stringify(Json.obj("selector" -> myPartition.selector, "fields" ->
-        // myPartition.fields, "limit" -> myPartition.limit, "skip" -> myPartition.skip))
-        jsonObject.add("selector", myPartition.selector)
         jsonObject.add("fields", myPartition.fields)
-        jsonObject.addProperty("skip", myPartition.skip)
         jsonObject.toString
       } else if (myPartition.queryUsed) {
-        // Json.stringify(Json.obj("selector" -> myPartition.selector,
-        // "limit" -> myPartition.limit, "skip" -> myPartition.skip))
-        jsonObject.add("selector", myPartition.selector)
         jsonObject.addProperty("limit", myPartition.limit)
-        jsonObject.addProperty("skip", myPartition.skip)
         jsonObject.toString
       } else {
         null

--- a/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/common/JsonUtil.scala
+++ b/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/common/JsonUtil.scala
@@ -16,27 +16,38 @@
  */
 package org.apache.bahir.cloudant.common
 
-import play.api.libs.json.JsValue
 import scala.util.control.Breaks._
 
+import com.google.gson.{JsonElement, JsonParser}
+
 object JsonUtil {
-  def getField(row: JsValue, field: String) : Option[JsValue] = {
+  def getField(row: JsonElement, field: String) : Option[JsonElement] = {
     var path = field.split('.')
     var currentValue = row
-    var finalValue: Option[JsValue] = None
+    var finalValue: Option[JsonElement] = None
     breakable {
       for (i <- path.indices) {
-        val f: Option[JsValue] = (currentValue \ path(i)).toOption
-        f match {
-          case Some(f2) => currentValue = f2
-          case None => break
-        }
-        if (i == path.length -1) {
-          // The leaf node
-          finalValue = Some(currentValue)
+        if (currentValue != null && currentValue.isJsonObject) {
+          val f: Option[JsonElement] =
+            Option(currentValue.getAsJsonObject.get(path(i)))
+          f match {
+            case Some(f2) => currentValue = f2
+            case None => break
+          }
+          if (i == path.length - 1) {
+            // The leaf node
+            finalValue = Some(currentValue)
+          }
         }
       }
     }
     finalValue
+  }
+
+  object JsonConverter {
+    val parser = new JsonParser
+    def toJson(value: Any): JsonElement = {
+      parser.parse(value.toString)
+    }
   }
 }

--- a/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/internal/ChangesReceiver.scala
+++ b/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/internal/ChangesReceiver.scala
@@ -42,7 +42,6 @@ class ChangesReceiver(config: CloudantChangesConfig)
         .connectTimeout(5, TimeUnit.SECONDS)
         .readTimeout(60, TimeUnit.SECONDS)
         .build
-    // Get normal _changes url
     val url = config.getChangesReceiverUrl.toString
 
     val builder = new Request.Builder().url(url)

--- a/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/internal/ChangesReceiver.scala
+++ b/sql-cloudant/src/main/scala/org/apache/bahir/cloudant/internal/ChangesReceiver.scala
@@ -19,6 +19,7 @@ package org.apache.bahir.cloudant.internal
 import java.io.{BufferedReader, InputStreamReader}
 import java.util.concurrent.TimeUnit
 
+import com.google.gson.JsonParser
 import okhttp3._
 
 import org.apache.spark.storage.StorageLevel
@@ -72,8 +73,11 @@ class ChangesReceiver(config: CloudantChangesConfig)
         }
       }
     } else {
-      val errorMsg = "Error retrieving _changes feed " + config.getDbname + ": " + status_code
+      val responseAsJson = new JsonParser().parse(response.body.string)
+      val errorMsg = "Error retrieving _changes feed data from database " + "'" +
+        config.getDbname + "' with response code " + status_code + ": " + responseAsJson.toString
       reportError(errorMsg, new CloudantException(errorMsg))
+      CloudantChangesConfig.receiverErrorMsg = errorMsg
     }
   }
 

--- a/sql-cloudant/src/test/scala/org/apache/bahir/cloudant/CloudantOptionSuite.scala
+++ b/sql-cloudant/src/test/scala/org/apache/bahir/cloudant/CloudantOptionSuite.scala
@@ -98,8 +98,9 @@ class CloudantOptionSuite extends ClientSparkFunSuite with BeforeAndAfter {
     val thrown = intercept[CloudantException] {
       spark.read.format("org.apache.bahir.cloudant").load("n_flight")
     }
-    assert(thrown.getMessage === s"Error retrieving _changes feed data" +
-      s" from database 'n_flight': HTTP/1.1 401 Unauthorized")
+    assert(thrown.getMessage === "Error retrieving _changes feed data" +
+      " from database 'n_flight' with response code 401: {\"error\":\"unauthorized\"," +
+      "\"reason\":\"Name or password is incorrect.\"}")
   }
 
   testIfEnabled("string with valid value for cloudant.numberOfRetries option") {

--- a/sql-cloudant/src/test/scala/org/apache/bahir/cloudant/CloudantOptionSuite.scala
+++ b/sql-cloudant/src/test/scala/org/apache/bahir/cloudant/CloudantOptionSuite.scala
@@ -42,7 +42,6 @@ class CloudantOptionSuite extends ClientSparkFunSuite with BeforeAndAfter {
     }
     assert(thrown.getMessage === s"spark.cloudant.endpoint parameter " +
       s"is invalid. Please supply the valid option '_all_docs' or '_changes'.")
-
   }
 
   testIfEnabled("empty username option throws an error message") {
@@ -101,5 +100,32 @@ class CloudantOptionSuite extends ClientSparkFunSuite with BeforeAndAfter {
     }
     assert(thrown.getMessage === s"Error retrieving _changes feed data" +
       s" from database 'n_flight': HTTP/1.1 401 Unauthorized")
+  }
+
+  testIfEnabled("string with valid value for cloudant.numberOfRetries option") {
+    spark = SparkSession.builder().config(conf)
+      .config("cloudant.host", TestUtils.getHost)
+      .config("cloudant.username", TestUtils.getUsername)
+      .config("cloudant.password", TestUtils.getPassword)
+      .config("cloudant.numberOfRetries", "5")
+      .getOrCreate()
+
+    val df = spark.read.format("org.apache.bahir.cloudant").load("n_booking")
+    assert(df.count() === 2)
+  }
+
+  testIfEnabled("invalid value for cloudant.numberOfRetries option throws an error message") {
+    spark = SparkSession.builder().config(conf)
+      .config("cloudant.host", TestUtils.getHost)
+      .config("cloudant.username", TestUtils.getUsername)
+      .config("cloudant.password", TestUtils.getPassword)
+      .config("cloudant.numberOfRetries", "five")
+      .getOrCreate()
+
+    val thrown = intercept[CloudantException] {
+      spark.read.format("org.apache.bahir.cloudant").load("db")
+    }
+    assert(thrown.getMessage === s"Option \'cloudant.numberOfRetries\' failed with exception " +
+      s"""java.lang.NumberFormatException: For input string: "five"""")
   }
 }


### PR DESCRIPTION
_What_ 
Refactor sql-cloudant to use Cloudant's` java-cloudant` features

_How_
- Use java-cloudant’s executeRequest for HTTP requests against _all_docs endpoint
- Added HTTP 429 backoff with default settings
- Simplified caught exception and message for schema size
- Replaced scala http library with okhttp library for changes receiver
- Updated streaming CloudantReceiver class to use improved ChangesRowScanner method
- Replaced Play JSON with GSON library
- Updated save operation to use `java-cloudant` bulk API
- Use `_changes` feed filter option for Cloudant/CouchDB 2.x and greater
