### PR TITLE
[BAHIR-181] username and password should be available for pyspark when using mqtt streaming

### DIFF
--- a/streaming-mqtt/python/mqtt.py
+++ b/streaming-mqtt/python/mqtt.py
@@ -44,6 +44,26 @@ class MQTTUtils(object):
         return DStream(jstream, ssc, UTF8Deserializer())
 
     @staticmethod
+    def createStream(ssc, brokerUrl, topic,
+                     username, password,
+                     storageLevel=StorageLevel.MEMORY_AND_DISK_2):
+        """
+        Create an input stream that pulls messages from a Mqtt Broker.
+
+        :param ssc:  StreamingContext object
+        :param brokerUrl:  Url of remote mqtt publisher
+        :param topic:  topic name to subscribe to
+        :param username:  the vitual host name : username or username
+        :param password:  the password of mqtt
+        :param storageLevel:  RDD storage level.
+        :return: A DStream object
+        """
+        jlevel = ssc._sc._getJavaStorageLevel(storageLevel)
+        helper = MQTTUtils._get_helper(ssc._sc)
+        jstream = helper.createStream(ssc._jssc, brokerUrl, topic, jlevel, username, password)
+        return DStream(jstream, ssc, UTF8Deserializer())
+
+    @staticmethod
     def createPairedStream(ssc, brokerUrl, topics,
                      storageLevel=StorageLevel.MEMORY_AND_DISK_2):
         """

--- a/streaming-mqtt/src/main/scala/org/apache/spark/streaming/mqtt/MQTTUtils.scala
+++ b/streaming-mqtt/src/main/scala/org/apache/spark/streaming/mqtt/MQTTUtils.scala
@@ -164,6 +164,7 @@ object MQTTUtils {
     createStream(jssc.ssc, brokerUrl, topic, storageLevel, None, Option(username),
         Option(password), None, None, None, None, None)
   }
+
   /**
    * Create an input stream that receives messages pushed by a MQTT publisher.
    * @param jssc               JavaStreamingContext object

--- a/streaming-mqtt/src/main/scala/org/apache/spark/streaming/mqtt/MQTTUtils.scala
+++ b/streaming-mqtt/src/main/scala/org/apache/spark/streaming/mqtt/MQTTUtils.scala
@@ -628,7 +628,7 @@ private[mqtt] class MQTTUtilsPythonHelper {
       storageLevel: StorageLevel,
       username: String,
       password: String
-    ): JavaDStream[String]= {
+    ): JavaDStream[String] = {
      MQTTUtils.createStream(jssc, brokerUrl, topic, storageLevel, username, password)
   }
 }

--- a/streaming-mqtt/src/main/scala/org/apache/spark/streaming/mqtt/MQTTUtils.scala
+++ b/streaming-mqtt/src/main/scala/org/apache/spark/streaming/mqtt/MQTTUtils.scala
@@ -148,6 +148,27 @@ object MQTTUtils {
    * @param jssc               JavaStreamingContext object
    * @param brokerUrl          Url of remote MQTT publisher
    * @param topic              Topic name to subscribe to
+   * @param storageLevel       RDD storage level.
+   * @param username           Username for authentication to the mqtt publisher
+   * @param password           Password for authentication to the mqtt publisher
+   */
+  def createStream(
+      jssc: JavaStreamingContext,
+      brokerUrl: String,
+      topic: String,
+      storageLevel: StorageLevel,
+      username: String,
+      password: String
+    ): JavaReceiverInputDStream[String] = {
+    implicitly[ClassTag[AnyRef]].asInstanceOf[ClassTag[String]]
+    createStream(jssc.ssc, brokerUrl, topic, storageLevel, None, Option(username),
+        Option(password), None, None, None, None, None)
+  }
+  /**
+   * Create an input stream that receives messages pushed by a MQTT publisher.
+   * @param jssc               JavaStreamingContext object
+   * @param brokerUrl          Url of remote MQTT publisher
+   * @param topic              Topic name to subscribe to
    * @param clientId           ClientId to use for the mqtt connection
    * @param username           Username for authentication to the mqtt publisher
    * @param password           Password for authentication to the mqtt publisher
@@ -597,5 +618,16 @@ private[mqtt] class MQTTUtilsPythonHelper {
       storageLevel: StorageLevel
       ): JavaDStream[(String, Array[Byte])] = {
     MQTTUtils.createPairedByteArrayStream(jssc, brokerUrl, topics, storageLevel)
+  }
+
+  def createStream(
+      jssc: JavaStreamingContext,
+      brokerUrl: String,
+      topic: String,
+      storageLevel: StorageLevel,
+      username: String,
+      password: String
+    ): JavaDStream[String]= {
+     MQTTUtils.createStream(jssc, brokerUrl, topic, storageLevel, username, password)
   }
 }


### PR DESCRIPTION
When using spark-streaming-mqtt with pyspark to access rabbitmq, I  found there are no username and password provied for python api;

These two params are important and necessary for rabbitmq especially when using rabbitmq virtual hosts, so I added a group of functions here;