### PR TITLE
Ignore flaky PubNub integration test

### DIFF
--- a/streaming-pubnub/README.md
+++ b/streaming-pubnub/README.md
@@ -74,4 +74,10 @@ For complete code examples, please review _examples_ directory.
 
 ## Unit Test
 
-Unit tests take advantage of publicly available _demo_ subscription and and publish key, which has limited request rate.
+Unit tests take advantage of publicly available _demo_ subscription and publish key, which have limited request rate.
+Anyone playing with PubNub _demo_ credentials may interrupt the tests, therefore execution of integration tests
+has to be explicitly enabled by setting environment variable _ENABLE_PUBNUB_TESTS_ to _1_.
+
+    cd streaming-pubnub
+    export ENABLE_PUBNUB_TESTS=1
+    mvn clean test

--- a/streaming-pubnub/src/test/scala/org/apache/spark/streaming/pubnub/PubNubStreamSuite.scala
+++ b/streaming-pubnub/src/test/scala/org/apache/spark/streaming/pubnub/PubNubStreamSuite.scala
@@ -28,12 +28,12 @@ import org.scalatest.concurrent.Eventually
 import org.scalatest.time
 import org.scalatest.time.Span
 
-import org.apache.spark.SparkFunSuite
+import org.apache.spark.ConditionalSparkFunSuite
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.streaming.Seconds
 import org.apache.spark.streaming.StreamingContext
 
-class PubNubStreamSuite extends SparkFunSuite with Eventually with BeforeAndAfter {
+class PubNubStreamSuite extends ConditionalSparkFunSuite with Eventually with BeforeAndAfter {
   val subscribeKey = "demo"
   val publishKey = "demo"
   val channel = "test"
@@ -41,6 +41,8 @@ class PubNubStreamSuite extends SparkFunSuite with Eventually with BeforeAndAfte
   var ssc: StreamingContext = _
   var configuration: PNConfiguration = _
   var client: PubNub = _
+
+  def shouldRunTest(): Boolean = sys.env.get("ENABLE_PUBNUB_TESTS").contains("1")
 
   override def beforeAll(): Unit = {
     configuration = new PNConfiguration()
@@ -63,7 +65,7 @@ class PubNubStreamSuite extends SparkFunSuite with Eventually with BeforeAndAfte
     }
   }
 
-  test("Stream receives messages") {
+  testIf("Stream receives messages", shouldRunTest) {
     val nbOfMsg = 5
     var publishedMessages: List[JsonObject] = List()
     @volatile var receivedMessages: Set[SparkPubNubMessage] = Set()
@@ -99,7 +101,7 @@ class PubNubStreamSuite extends SparkFunSuite with Eventually with BeforeAndAfte
     }
   }
 
-  test("Message filtering") {
+  testIf("Message filtering", shouldRunTest) {
     val config = new PNConfiguration()
     config.setSubscribeKey(subscribeKey)
     config.setPublishKey(publishKey)
@@ -132,7 +134,7 @@ class PubNubStreamSuite extends SparkFunSuite with Eventually with BeforeAndAfte
     }
   }
 
-  test("Test time token") {
+  testIf("Test time token", shouldRunTest) {
     val config = new PNConfiguration()
     config.setSubscribeKey(subscribeKey)
     config.setPublishKey(publishKey)


### PR DESCRIPTION
Anyone playing with PubNub demo can interrupt integration tests. Not to incorrectly fail builds, let us mute tests directly interacting with PubNub cloud (similar to Google PubSub). False alarms can be observed in pull requests #75 and #76. After merging #73, changes are minimal :).