### PR TITLE
Updated sql-cloudant dependencies

### DIFF
--- a/sql-cloudant/pom.xml
+++ b/sql-cloudant/pom.xml
@@ -63,26 +63,6 @@
       <version>1.3.1</version>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-annotations</artifactId>
-      <version>2.6.7</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-      <version>2.6.7</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>2.6.7</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jsr310</artifactId>
-      <version>2.6.7</version>
-    </dependency>
-    <dependency>
       <groupId>org.scalaj</groupId>
       <artifactId>scalaj-http_${scala.binary.version}</artifactId>
     </dependency>

--- a/sql-cloudant/pom.xml
+++ b/sql-cloudant/pom.xml
@@ -50,12 +50,12 @@
     <dependency>
       <groupId>com.cloudant</groupId>
       <artifactId>cloudant-client</artifactId>
-      <version>2.11.0</version>
+      <version>2.17.0</version>
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
-      <version>3.9.0</version>
+      <version>3.12.2</version>
     </dependency>
     <dependency>
       <groupId>com.typesafe</groupId>

--- a/sql-cloudant/src/test/scala/org/apache/bahir/cloudant/CloudantChangesDFSuite.scala
+++ b/sql-cloudant/src/test/scala/org/apache/bahir/cloudant/CloudantChangesDFSuite.scala
@@ -24,7 +24,8 @@ import org.apache.spark.sql.SparkSession
 class CloudantChangesDFSuite extends ClientSparkFunSuite {
   val endpoint = "_changes"
 
-  before {
+  override def beforeAll() {
+    super.beforeAll()
     spark = SparkSession.builder().config(conf)
       .config("cloudant.protocol", TestUtils.getProtocol)
       .config("cloudant.host", TestUtils.getHost)
@@ -33,10 +34,6 @@ class CloudantChangesDFSuite extends ClientSparkFunSuite {
       .config("cloudant.endpoint", endpoint)
       .config("spark.streaming.unpersist", "false")
       .getOrCreate()
-  }
-
-  after {
-    spark.close()
   }
 
   testIf("load and save data from Cloudant database", TestUtils.shouldRunTest) {

--- a/sql-cloudant/src/test/scala/org/apache/bahir/cloudant/CloudantOptionSuite.scala
+++ b/sql-cloudant/src/test/scala/org/apache/bahir/cloudant/CloudantOptionSuite.scala
@@ -135,6 +135,7 @@ class CloudantOptionSuite extends ClientSparkFunSuite with BeforeAndAfter {
       spark.read.format("org.apache.bahir.cloudant").load("db")
     }
     assert(thrown.getMessage === s"Option \'cloudant.numberOfRetries\' failed with exception " +
-      s"""java.lang.NumberFormatException: For input string: "five"""")
+      s"java.lang.NumberFormatException: Illegal value for config key cloudant.numberOfRetries: " +
+      s"""For input string: "five"""")
   }
 }


### PR DESCRIPTION
_What_
Updated sql-cloudant dependencies

_How_
- Bumped java-cloudant to 2.17.0 and okhttp to 3.12.2

_Test_
- Updated exception message in failing test
- CloudantChangesDFSuite: Replaced before/after calls with an overrided beforeAll method