### PR TITLE
[BAHIR-217] Install of Oracle JDK 8 Failing in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,7 @@ jdk:
   - openjdk8
   - oraclejdk8
 
+dist: trusty
+
 script:
   - mvn -Pdistribution clean install


### PR DESCRIPTION
## What changes were proposed in this pull request?

Install of Oracle JDK 8 Failing in Travis CI. As a result, build is failing for new pull requests.

We need to make a small fix in   _.travis.yml_ file as mentioned in the issue here:
https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038
We just need to add 
`dist: trusty`

in the _.travis.yml_ file as mentioned in the issue above.

## How will these changes be tested?

Travis Build should successfully pass for this PR, thus testing the changes.