### PR TITLE
[BAHIR-239] Fixing bugs in SQSClient

### DIFF
--- a/sql-streaming-sqs/src/main/scala/org/apache/spark/sql/streaming/sqs/SqsClient.scala
+++ b/sql-streaming-sqs/src/main/scala/org/apache/spark/sql/streaming/sqs/SqsClient.scala
@@ -220,11 +220,12 @@ class SqsClient(sourceOptions: SqsSourceOptions,
           .standard()
           .withClientConfiguration(new ClientConfiguration().withMaxConnections(maxConnections))
           .withCredentials(instanceProfileCredentialsProvider)
+          .withRegion(region)
           .build()
       }
     } catch {
       case e: Exception =>
-        throw new SparkException(s"Error occured while creating Amazon SQS Client ${e.getMessage}")
+        throw new SparkException(s"Error occured while creating Amazon SQS Client", e)
     }
   }
 


### PR DESCRIPTION
## What Changes were proposed in this pull request?

This pull request fixes the following two issues:

1. Incomplete error message shows up when SQSClient fails to be created.
`org.apache.spark.SparkException: Error occured while creating Amazon SQS Client null`

2. AWS region is not honoured when authentication mode is keys.