### PR TITLE
Bump google-api-services-pubsub to 2.0.0

### DIFF
--- a/streaming-pubsub/pom.xml
+++ b/streaming-pubsub/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-pubsub</artifactId>
-      <version>v1-rev355-1.22.0</version>
+      <version>v1-rev20230124-2.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud.bigdataoss</groupId>


### PR DESCRIPTION
The Google API clients are now at major version 2, which, if used in the same project, will cause compatibility issues.

For example, `org.apache.bahir:spark-streaming-pubsub_2.12:2.4.0` uses `com.google.apis:google-api-services-pubsub:v1-rev355-1.22.0` while Spark GCS connector **2.2.11** is using **2.2.0**. Then in runtime, we get

```
Caused by: java.lang.IllegalStateException: You are currently running with version 2.2.0 of google-api-client. You need at least version 1.15 of google-api-client to run version 1.22.0 of the Google Cloud Pub/Sub API library.
```